### PR TITLE
Version notation fix

### DIFF
--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -244,8 +244,13 @@ def get_cml_sdwan_image_definition(
 
 
 def get_sdwan_lab_parameters(software_version: str) -> List[int]:
-    major_release = int(software_version.split(".")[0])
-    minor_release = int(software_version.split(".")[1])
+    if '.' in software_version and '-' not in software_version:
+        major_release = int(software_version.split(".")[0])
+        minor_release = int(software_version.split(".")[1])
+    elif '.' not in software_version and '-' in software_version:
+        major_release = int(software_version.split("-")[0])
+        minor_release = int(software_version.split("-")[1])
+
     if major_release <= 19 or (major_release == 20 and minor_release < 4):
         sys.exit("Versions lower than 20.4 are not supported by the script.")
     elif major_release == 20 and minor_release in [4, 5, 6, 7, 8, 9, 10, 11]:

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -233,6 +233,8 @@ def get_cml_sdwan_image_definition(
                     f"Use setup task to upload the correct images."
                 )
         else:
+            for image_id in existing_image_definitions:
+                print(f'--> {image_id}\n')
             available_software_versions = [
                 image_id.split("-")[3] for image_id in existing_image_definitions
             ]

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -233,10 +233,9 @@ def get_cml_sdwan_image_definition(
                     f"Use setup task to upload the correct images."
                 )
         else:
-            for image_id in existing_image_definitions:
-                print(f'--> {image_id}\n')
             available_software_versions = [
-                image_id.split("-")[3] for image_id in existing_image_definitions
+                # If version notation is with hyphens we need join all the elements into one string
+                "-".join(image_id.split("-")[3:]) for image_id in existing_image_definitions
             ]
             sys.exit(
                 f'Requested SD-WAN {node_definition.split("-")[2].title()} software image version '
@@ -246,6 +245,7 @@ def get_cml_sdwan_image_definition(
 
 
 def get_sdwan_lab_parameters(software_version: str) -> List[int]:
+    # Conditional required for version notation with hyphens. It happens if images are imported to CML from refplat
     if '.' in software_version and '-' not in software_version:
         major_release = int(software_version.split(".")[0])
         minor_release = int(software_version.split(".")[1])


### PR DESCRIPTION
## Description

If an image is already present in CML (i.e., already imported from replace ISO), it may have <software-version> notation with hyphens instead of dots. This small patch fixes the handling of such notation in two places:
1) Validation of proper image for deployment
2) Listing of available images

It may be just a base to fix the notation handling in other parts of the code as well, I added support for hyphens in those two places because I don't have access to a fresh CML install to test image import via "setup" command here.

With this patch, I'll be able to deploy the lab with "sdwan-lab deploy 20.13.1" and "sdwan-lab deploy 20-13-1" commands. 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

