### PR TITLE
Dev 2.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added CML PATty support
 - Bump pyats from 24.2 to 24.5
+- In delete task, print lab name when asking user to confirm if lab should be deleted
 
 # Catalyst SD-WAN Lab 2.0.11 [May 13, 2024]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# Catalyst SD-WAN Lab 2.0.10 [May 13, 2024]
+# Catalyst SD-WAN Lab 2.0.12 [2024]
+
+- Added CML PATty support
+
+# Catalyst SD-WAN Lab 2.0.11 [May 13, 2024]
 
 - Added sign task
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added CML PATty support
 - Bump pyats from 24.2 to 24.5
 - In delete task, print lab name when asking user to confirm if lab should be deleted
+- In add task, added check to avoid deploying labs with duplicate names (although CML allows labs with duplicate names, this creates confusion for other tasks where lab name is used)
 
 # Catalyst SD-WAN Lab 2.0.11 [May 13, 2024]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Catalyst SD-WAN Lab 2.0.12 [2024]
+# Catalyst SD-WAN Lab 2.0.12 [Jun 18, 2024]
 
 - Added CML PATty support
+- Bump pyats from 24.2 to 24.5
 
 # Catalyst SD-WAN Lab 2.0.11 [May 13, 2024]
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ The easiest way to run the tool is to provide all the lab variables in the rc fi
 
 Note that if password was not defined, the user will be prompted for a password.
 
+Note that MANAGER_IP can be:
+- an IP address: SD-WAN Manager will be reachable over this IP address. By default the IP address should come from the same subnet as CML IP, unless custom bridge is specified during deploy task.
+- a PATty port in format "pat:<outside-port>": SD-WAN Manager will be reachable over CML IP port <outside-port>. Before using this option, PATTy needs to be enabled on the CML server as per [CML documentation](https://developer.cisco.com/docs/modeling-labs/patty-tool-overview/).
+
 ### Task-specific Parameters
 Task-specific parameters and options are defined after the task is provided. Each task has its own set of parameters. Check the task documentation to learn more about task-specific parameters.
 

--- a/catalyst_sdwan_lab/data/cml_lab_definition/deploy/cml-base-topology.j2
+++ b/catalyst_sdwan_lab/data/cml_lab_definition/deploy/cml-base-topology.j2
@@ -15,7 +15,12 @@ nodes:
     label: Manager0{{ manager_num }}
     node_definition: cat-sdwan-manager
     ram: null
+{% if patty_used %}
+    tags:
+      - pat:{{ manager_port }}:443
+{% else %}
     tags: []
+{% endif %}
     x: -280
     y: -80
     interfaces:
@@ -773,7 +778,7 @@ lab:
   description: This lab was deployed using SD-WAN lab automation.
   notes: |-
     -- Do not delete this text --
-    manager_external_ip = {{ manager_external_ip }}
+    manager_external_ip = {{ manager_external_ip }}:{{ manager_port }}
     -- Do not delete this text --
   title: '{{ title }}'
   version: 0.2.1

--- a/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
+++ b/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
@@ -88,6 +88,7 @@ write_files:
         </vpn-instance>
         <vpn-instance>
           <vpn-id>512</vpn-id>
+{% if not patty_used %}
           <ip>
             <route>
               <prefix>0.0.0.0/0</prefix>
@@ -96,10 +97,15 @@ write_files:
               </next-hop>
             </route>
           </ip>
+{% endif %}
           <interface>
             <if-name>eth0</if-name>
             <ip>
+{% if patty_used %}
+              <dhcp-client>true</dhcp-client>
+{% else %}
               <address>{{ manager_external_ip }}{{ external_subnet_mask }}</address>
+{% endif %}
             </ip>
             <shutdown>false</shutdown>
           </interface>

--- a/catalyst_sdwan_lab/tasks/add.py
+++ b/catalyst_sdwan_lab/tasks/add.py
@@ -60,6 +60,7 @@ def main(
     cml_user: str,
     cml_password: str,
     manager_ip: str,
+    manager_port: int,
     manager_user: str,
     manager_password: str,
     lab_name: str,
@@ -124,7 +125,10 @@ def main(
 
     log.info("Logging in to SD-WAN Manager...")
     manager_session = create_manager_session(
-        url=manager_ip, username=manager_user, password=manager_password
+        url=manager_ip,
+        username=manager_user,
+        password=manager_password,
+        port=manager_port,
     )
     manager_config_settings = manager_session.endpoints.configuration_settings
     org_name = manager_config_settings.get_organizations()[0].org

--- a/catalyst_sdwan_lab/tasks/backup.py
+++ b/catalyst_sdwan_lab/tasks/backup.py
@@ -18,6 +18,7 @@ from cisco_sdwan.base.rest_api import Rest
 from cisco_sdwan.tasks.implementation import BackupArgs, TaskBackup
 from jinja2 import Environment, FileSystemLoader
 from ruamel.yaml import YAML
+from ruamel.yaml.scalarstring import LiteralScalarString
 from virl2_client import ClientLibrary
 from virl2_client.models.cl_pyats import ClPyats
 
@@ -160,6 +161,7 @@ def main(
     cml_user: str,
     cml_password: str,
     manager_ip: str,
+    manager_port: int,
     manager_user: str,
     manager_password: str,
     lab_name: str,
@@ -192,7 +194,10 @@ def main(
     # Login to SD-WAN Manager
     log.info("Logging in to SD-WAN Manager...")
     manager_session = create_manager_session(
-        url=manager_ip, username=manager_user, password=manager_password
+        url=manager_ip,
+        username=manager_user,
+        password=manager_password,
+        port=manager_port,
     )
     manager_config_settings = manager_session.endpoints.configuration_settings
     org_name = manager_config_settings.get_organizations()[0].org
@@ -369,9 +374,9 @@ def main(
                     "cat-sdwan-controller",
                     "cat-sdwan-edge",
                 ]:
-                    lab_extract["nodes"][i]["configuration"] = custom_node_backup[
-                        lab_extract["nodes"][i]["label"]
-                    ]
+                    lab_extract["nodes"][i]["configuration"] = LiteralScalarString(
+                        custom_node_backup[lab_extract["nodes"][i]["label"]]
+                    )
 
             os.mkdir(workdir)
             with open(rf"{workdir}/cml_topology.yaml", "w") as file:
@@ -388,7 +393,7 @@ def main(
             )
 
             with Rest(
-                base_url=f"https://{manager_ip}",
+                base_url=f"https://{manager_ip}:{manager_port}",
                 username=manager_user,
                 password=manager_password,
             ) as api:

--- a/catalyst_sdwan_lab/tasks/delete.py
+++ b/catalyst_sdwan_lab/tasks/delete.py
@@ -26,14 +26,14 @@ def main(
         # so we ask user to make sure the lab names are unique
         if len(lab) > 1:
             exit(
-                f'There are multiple labs/topologies with name "{lab_name}". Please make sure '
+                f"There are multiple labs/topologies with name '{lab_name}'. Please make sure "
                 f"lab names are unique and rerun the delete task."
             )
         lab = lab[0]
 
         if not force:
             confirmation = input(
-                "\nThis will remove lab and all its data. "
+                f"\nThis will remove '{lab_name}' lab and all its data. "
                 "Are you sure you want to proceed? (yes/no): "
             )
             if confirmation.lower() != "yes":

--- a/catalyst_sdwan_lab/tasks/deploy.py
+++ b/catalyst_sdwan_lab/tasks/deploy.py
@@ -38,6 +38,7 @@ def main(
     cml: ClientLibrary,
     cml_ip: str,
     manager_ip: str,
+    manager_port: int,
     manager_mask: str,
     manager_gateway: str,
     manager_user: str,
@@ -46,6 +47,7 @@ def main(
     lab_name: str,
     bridge: str,
     dns_server: str,
+    patty_used: bool,
     retry: bool,
     loglevel: Union[int, str],
 ) -> None:
@@ -102,6 +104,10 @@ def main(
     # Encrypt SD-WAN Manager password to SHA512. The encrypted password will be used in bootstrap configuration.
     encrypted_manager_password = sha512_crypt.encrypt(manager_password, rounds=5000)
 
+    if patty_used:
+        # PATty should be used for SD-WAN Manager reachability. This means bridge configuration needs to be set to NAT
+        bridge = "NAT"
+
     cml_topology = cml_tp_tmpl.render(
         title=lab_name,
         manager_image=manager_image,
@@ -120,6 +126,8 @@ def main(
         external_gateway=manager_gateway,
         bridge=bridge,
         dns_server=dns_server,
+        manager_port=manager_port,
+        patty_used=patty_used,
     )
 
     if retry:
@@ -134,8 +142,10 @@ def main(
             )
     else:
         # Prepare and deploy the lab to CML
-        # Check if the IP allocated for SD-WAN Manager is not already it use.
-        check_manager_ip_is_free(manager_ip)
+
+        if not patty_used:
+            # If PATty is not used, check if the IP allocated for SD-WAN Manager is not already it use.
+            check_manager_ip_is_free(manager_ip)
         log.info("Importing the lab...")
         lab = cml.import_lab(cml_topology, lab_name)
         track_progress(log, "Waiting for nodes to boot...")
@@ -144,7 +154,7 @@ def main(
 
     # Wait for SD-WAN Manager API to be available
     manager_session = wait_for_manager_session(
-        manager_ip, manager_user, manager_password, log
+        manager_ip, manager_port, manager_user, manager_password, log
     )
     # Configure basic settings like org-name, validator fqdn etc.
     configure_manager_basic_settings(manager_session, ca_chain, log)
@@ -175,6 +185,7 @@ def main(
 
     restore_manager_configuration(
         manager_ip,
+        manager_port,
         manager_user,
         manager_password,
         join(MANAGER_CONFIGS_DIR, f"v{config_version}"),
@@ -191,7 +202,7 @@ def main(
         f"#############################################\n"
         f"Lab is deployed.\n"
         f"CML URL: https://{cml_ip}\n"
-        f"SD-WAN Manager URL: https://{manager_ip}:8443\n"
+        f"SD-WAN Manager URL: https://{manager_ip}:{manager_port}\n"
         f"Use the username/password set with the script for CML and SD-WAN Manager login.\n"
         f"All other nodes use default username/password.\n"
         f"#############################################"

--- a/catalyst_sdwan_lab/tasks/deploy.py
+++ b/catalyst_sdwan_lab/tasks/deploy.py
@@ -86,8 +86,10 @@ def main(
         # this crete confusion for other tasks where lab name is used
         existing_lab_names = [lab.title for lab in cml.all_labs(show_all=True)]
         if lab_name in existing_lab_names:
-            exit(f"Lab with name '{lab_name}' already exists. "
-                 f"Please provide a different name to avoid confusion.")
+            exit(
+                f"Lab with name '{lab_name}' already exists. "
+                f"Please provide a different name to avoid confusion."
+            )
     else:
         # User didn't provide lab name, generate by default
         # Find existing sdwan labs names

--- a/catalyst_sdwan_lab/tasks/deploy.py
+++ b/catalyst_sdwan_lab/tasks/deploy.py
@@ -80,7 +80,15 @@ def main(
     # Prepare the CA for controllers certificate signing
     ca_cert, ca_key, ca_chain = load_certificate_details()
 
-    if not lab_name:
+    if lab_name:
+        # Verify lab name is not duplicated
+        # Although CML allows labs with same name,
+        # this crete confusion for other tasks where lab name is used
+        existing_lab_names = [lab.title for lab in cml.all_labs(show_all=True)]
+        if lab_name in existing_lab_names:
+            exit(f"Lab with name '{lab_name}' already exists. "
+                 f"Please provide a different name to avoid confusion.")
+    else:
         # User didn't provide lab name, generate by default
         # Find existing sdwan labs names
         lab_list_search = [

--- a/catalyst_sdwan_lab/tasks/restore.py
+++ b/catalyst_sdwan_lab/tasks/restore.py
@@ -197,9 +197,9 @@ def main(
             manager_node = node
         elif node.node_definition == "cat-sdwan-controller":
             # Add Controller VPN 0 IP to the list
-            vpn0_ip_search = re.search(r"(172.16.0.1\d+)/24", node.config)
+            vpn0_ip_search = re.search(r"(172.16.0.1\d+)/24", node.configuration)
             system_ip_search = re.search(
-                r"<system-ip>([\d.]+)</system-ip>", node.config
+                r"<system-ip>([\d.]+)</system-ip>", node.configuration
             )
             if vpn0_ip_search and system_ip_search:
                 vpn0_ip = vpn0_ip_search.group(1)
@@ -211,7 +211,7 @@ def main(
             node.start()
         elif node.node_definition == "cat-sdwan-validator":
             # Add Validator VPN 0 IP to the list
-            vpn0_ip_search = re.search(r"(172.16.0.2\d+)/24", node.config)
+            vpn0_ip_search = re.search(r"(172.16.0.2\d+)/24", node.configuration)
             if vpn0_ip_search:
                 vpn0_ip = vpn0_ip_search.group(1)
                 control_components[vpn0_ip] = "validator"
@@ -221,7 +221,7 @@ def main(
             # To workaround CML problem, after config export for this node
             # we need to add 'no shutdown' under all interfaces
             node.config = re.sub(
-                r"(interface\sGigabitEthernet\d\n)", r"\1 no shutdown\n", node.config
+                r"(interface\sGigabitEthernet\d\n)", r"\1 no shutdown\n", node.configuration
             )
             node.start()
         elif node.node_definition != "cat-sdwan-edge":
@@ -399,14 +399,14 @@ def main(
         if node.node_definition == "cat-sdwan-edge" and node.is_booted() is False:
             # Before we boot Edge we need to update the cloud-init OTP token
             uuid_search = re.search(
-                r"vinitparam:[\w\W]+?uuid\s:\s([\w-]+)", node.config
+                r"vinitparam:[\w\W]+?uuid\s:\s([\w-]+)", node.configuration
             )
             if uuid_search:
                 uuid = uuid_search.group(1)
                 token = uuid_to_token[uuid]
                 # Update node config with new otp token
                 node.config = re.sub(
-                    r"(vinitparam:[\w\W]+?otp\s:)\s(\w+)", rf"\1 {token}", node.config
+                    r"(vinitparam:[\w\W]+?otp\s:)\s(\w+)", rf"\1 {token}", node.configuration
                 )
                 wan_edges_to_onboard.append(uuid)
             node.start()

--- a/catalyst_sdwan_lab/tasks/restore.py
+++ b/catalyst_sdwan_lab/tasks/restore.py
@@ -221,7 +221,9 @@ def main(
             # To workaround CML problem, after config export for this node
             # we need to add 'no shutdown' under all interfaces
             node.config = re.sub(
-                r"(interface\sGigabitEthernet\d\n)", r"\1 no shutdown\n", node.configuration
+                r"(interface\sGigabitEthernet\d\n)",
+                r"\1 no shutdown\n",
+                node.configuration,
             )
             node.start()
         elif node.node_definition != "cat-sdwan-edge":
@@ -406,7 +408,9 @@ def main(
                 token = uuid_to_token[uuid]
                 # Update node config with new otp token
                 node.config = re.sub(
-                    r"(vinitparam:[\w\W]+?otp\s:)\s(\w+)", rf"\1 {token}", node.configuration
+                    r"(vinitparam:[\w\W]+?otp\s:)\s(\w+)",
+                    rf"\1 {token}",
+                    node.configuration,
                 )
                 wan_edges_to_onboard.append(uuid)
             node.start()

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -373,6 +373,7 @@ def onboard_control_components(
 
 def restore_manager_configuration(
     manager_ip: str,
+    manager_port: int,
     manager_user: str,
     manager_password: str,
     workdir: str,
@@ -384,7 +385,7 @@ def restore_manager_configuration(
     sastre_task_args = RestoreArgs(workdir=workdir, attach=attach, tag="all")
 
     with Rest(
-        base_url=f"https://{manager_ip}",
+        base_url=f"https://{manager_ip}:{manager_port}",
         username=manager_user,
         password=manager_password,
     ) as api:
@@ -469,7 +470,11 @@ def track_progress(log: Logger, message: str) -> None:
 
 
 def wait_for_manager_session(
-    manager_ip: str, manager_user: str, manager_password: str, log: Logger
+    manager_ip: str,
+    manager_patty_port: int,
+    manager_user: str,
+    manager_password: str,
+    log: Logger,
 ) -> ManagerSession:
     """
     Retry to log in to SD-WAN Manager until API is up
@@ -483,7 +488,10 @@ def wait_for_manager_session(
     while True:
         try:
             manager_session = create_manager_session(
-                url=manager_ip, username=manager_user, password=manager_password
+                url=manager_ip,
+                port=manager_patty_port,
+                username=manager_user,
+                password=manager_password,
             )
         except (
             ConnectionRefusedError,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1296,119 +1296,116 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyats"
-version = "24.2"
+version = "24.5"
 description = "pyATS - Python Automation Test System"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:e2e24947c4c122988ac903a595bcd53789c0ac5107edac6db67ac5c89ff1209f"},
-    {file = "pyats-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:608df7a48f24684c2d20db2adf43ac346de3ddfdb963874de090146a85328944"},
-    {file = "pyats-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1636bfa4b220940f01e119e6acb69e1b834ae72fc2a4f36a7d5c1059d85e346f"},
-    {file = "pyats-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:45f41d386076506bad3a6b9fa82b6155e994e67fa509cee77363190f365f6838"},
-    {file = "pyats-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:020ad8591f2d955dd96074aa3d0168bb183c87a177f76cca21e0790c5cef12d0"},
-    {file = "pyats-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:0c37b1ffdea386d18d33cb949f2fa410d84f142bb51b494133fd888be86c117d"},
-    {file = "pyats-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:0e33a1b770a31b72fc92ab0bd95c6f66168ac858f735a54e2b44c5aac5ea34a8"},
-    {file = "pyats-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:99c3721d1dd5d6178337f3fa825d809d4477d88434b5afc1b0d1a47261ca69bd"},
-    {file = "pyats-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:fbd0bc671a8fb88f94ac6aa4b1d38f6f0c4e5dc6a46047ac4532f522eba0d83c"},
-    {file = "pyats-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:f7e3dcd7bbd959275c4f170df040fd2fd05756d9b29e148c25f3d81e9be13b9b"},
-    {file = "pyats-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:526a48918c3763375ed8f1d75faf484e0abe80349fa96f36c316f755bc21cf58"},
-    {file = "pyats-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0882dc7f699ef546be069f03c5a28d7f67c9f9a669ea45cc9ef774a4cd9f0359"},
-    {file = "pyats-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:e4806526a6df2d77313e80b33ca7899bc512a5c62317b19d9a83d0c916292fef"},
-    {file = "pyats-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:fa17e4dd82ec1bcccb6b85fb50212f5ca2e195c50a80c12dfdd8c029aa0461f1"},
-    {file = "pyats-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:245ee695e284fe71316b4e79dca680290bc4a1edc02ce27d15ff81a2db177fb7"},
-    {file = "pyats-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:174d1cd5cb3fb4cee491eda3a8b22fd7764aee46d80abf384ea2c2dc53acd9ae"},
+    {file = "pyats-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:671b8f8b6ebdc9744f2baa2a549247520e918d8376c0005835b67d3e7badaa24"},
+    {file = "pyats-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:cab7f8c61a730d5dfacfd6963f7af67849a52e4d63c9dbef4d7019e99eb34407"},
+    {file = "pyats-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:789f8a309d494bb4b8ac4ef8a0141dc9fc762827d3130ed7335aa1140d266092"},
+    {file = "pyats-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:43ddfe0874580d463da050146dc56ff55a35f03fcf889afa3fa7bca24f5c85a3"},
+    {file = "pyats-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:452f4e615907539cbec1f506ccdc2ab351a308d7b590295c14a51cf771329182"},
+    {file = "pyats-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:d41969f1f22eff17736c684440272c3c05415aab363ecca8744f7fb17b960922"},
+    {file = "pyats-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:80f2ae60ade858a3bb5957a9d2d647ff0be5a2f18641a243a95eaa6300837ff6"},
+    {file = "pyats-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:d2e0c9cfa451450ccd9b0ca4103f38fc354dbf55aa9d7e77816e775232a2ac8f"},
+    {file = "pyats-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:adda488fa86d5067585833aad7fa2f86bdaf76da522586e36875818180f34a46"},
+    {file = "pyats-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:369c5d43d862f75db5b10d803fd29c8c19b13f9e23bbb491b3fd4baa81ba1085"},
+    {file = "pyats-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6441e08015935c79f1face32c72ba807ab5cfeb2fdf1e44849620921dc3f2434"},
+    {file = "pyats-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:e748719a47f4827295021ee41c470595ea46bf5e57702a1a56e9e3a849aa5be8"},
+    {file = "pyats-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5835702e960f66e8916450d07173223ae2f0929f0167c6f61fbdaef909319983"},
+    {file = "pyats-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f85d8c03f707b5d2206ef32676b1793c8b0300129b5bb7510205a582b212a5d4"},
+    {file = "pyats-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:dd4f437a87949521f3d1d5b9a5683c3dab466dbd1ca7b38bdd749758244f3fb4"},
 ]
 
 [package.dependencies]
 packaging = ">=20.0"
-"pyats.aereport" = ">=24.2.0,<24.3.0"
-"pyats.aetest" = ">=24.2.0,<24.3.0"
-"pyats.async" = ">=24.2.0,<24.3.0"
-"pyats.connections" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.easypy" = ">=24.2.0,<24.3.0"
-"pyats.kleenex" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.reporter" = ">=24.2.0,<24.3.0"
-"pyats.results" = ">=24.2.0,<24.3.0"
-"pyats.tcl" = ">=24.2.0,<24.3.0"
-"pyats.topology" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.aereport" = ">=24.5.0,<24.6.0"
+"pyats.aetest" = ">=24.5.0,<24.6.0"
+"pyats.async" = ">=24.5.0,<24.6.0"
+"pyats.connections" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.easypy" = ">=24.5.0,<24.6.0"
+"pyats.kleenex" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.reporter" = ">=24.5.0,<24.6.0"
+"pyats.results" = ">=24.5.0,<24.6.0"
+"pyats.tcl" = ">=24.5.0,<24.6.0"
+"pyats.topology" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 
 [package.extras]
-full = ["cookiecutter", "genie (>=24.2.0,<24.3.0)", "genie.libs.robot (>=24.2.0,<24.3.0)", "genie.telemetry (>=24.2.0,<24.3.0)", "genie.trafficgen (>=24.2.0,<24.3.0)", "pyats.contrib (>=24.2.0,<24.3.0)", "pyats.robot (>=24.2.0,<24.3.0)"]
-library = ["genie (>=24.2.0,<24.3.0)"]
-robot = ["genie.libs.robot (>=24.2.0,<24.3.0)", "pyats.robot (>=24.2.0,<24.3.0)"]
+full = ["cookiecutter", "genie (>=24.5.0,<24.6.0)", "genie.libs.robot (>=24.5.0,<24.6.0)", "genie.telemetry (>=24.5.0,<24.6.0)", "genie.trafficgen (>=24.5.0,<24.6.0)", "pyats.contrib (>=24.5.0,<24.6.0)", "pyats.robot (>=24.5.0,<24.6.0)"]
+library = ["genie (>=24.5.0,<24.6.0)"]
+robot = ["genie.libs.robot (>=24.5.0,<24.6.0)", "pyats.robot (>=24.5.0,<24.6.0)"]
 template = ["cookiecutter"]
 
 [[package]]
 name = "pyats-aereport"
-version = "24.2"
+version = "24.5"
 description = "pyATS AEreport: Result Collection and Reporting"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.aereport-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c96ec142ed7043191c7e76e45db57114c4d407412a438d8811004112bd78d3d6"},
-    {file = "pyats.aereport-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:a25d54039d30160d002f478147240bb830a18c167335411ab4f6fb45a4d0dd78"},
-    {file = "pyats.aereport-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:007eda00c059df1c7bdc9099dde0ad41995d9ee07079655b560b42e469b92196"},
-    {file = "pyats.aereport-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:95d6caca82f5b0d506b89df2f93e15015f33bf20e66e7fcd7159010b11a00eb3"},
-    {file = "pyats.aereport-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:18c1020cc805a427ea1f7e08e5c076ccca8c89f1af78c5ff442af97e8f50badd"},
-    {file = "pyats.aereport-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:bc675da8d37609f061c0a2a914100dee74f6e3fc6351f1ce87c7fc71222fc2e7"},
-    {file = "pyats.aereport-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:071fafe5cfe169dde205d82cbeeb69018bca84606c67a77f22cfd7a5bdcfd54c"},
-    {file = "pyats.aereport-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:c27ca84fbeddc266bbb34e003947d4791c0019f9b9a543a31cd581d1d7fce8dd"},
-    {file = "pyats.aereport-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:04e61eb241df86f5c0d9e4f9046718a8ba6f76f97d57e1df42a5ca977bd55074"},
-    {file = "pyats.aereport-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:5be6832105b8db3313ac157c66c4a44466dc477b4813c0fbd4421dc918d8263d"},
-    {file = "pyats.aereport-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:4af0e456eb0c533507a8a6bbce3ae5455919c6c67171dc6f0de27ff751620fa1"},
-    {file = "pyats.aereport-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:83d066f73f660b141ce8e42d0ced191bbb2fb641213f91073e13067926386ec9"},
-    {file = "pyats.aereport-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:14377c8741618ad61bebdb1a5cdf3d10e696eca4946ac52761fe73af95b9944b"},
-    {file = "pyats.aereport-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a82a300bef22ff62faebcc745ad8fc99d31b584e69badd98677fa5e45cdeee33"},
-    {file = "pyats.aereport-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:4d1a03945722e945595fd90a431c9e2e02f21fefcaf69d8eb835df9da591d61f"},
-    {file = "pyats.aereport-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:33a41b3090b2ebe93087b36c6dcf25002e84a870772de716729393e9e251282c"},
+    {file = "pyats.aereport-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:af2be04005bfe9d7016f83552daaee263c88fbb984aa66a4f028a37b3af282d5"},
+    {file = "pyats.aereport-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:e9f7e7606581c253e4002775caa4e000cb2ae04fbea0e50abe3f525e8f390800"},
+    {file = "pyats.aereport-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:7efcd8e6577a45ddbdd65afecb2147459678067321953dd77009db1cb7e4494a"},
+    {file = "pyats.aereport-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:fb4cc30ff7240251b9a36935a01688a0dbe711bb7ed06c950d784dc464c2ebf2"},
+    {file = "pyats.aereport-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:cdb0dff21eeedb09ab5e9d4c4a7e07a68055ea596d4589e12c502e18f4ccca7c"},
+    {file = "pyats.aereport-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:720103c4744d42d37c85b9e3bce6cc96d007f5230362d4380faea001f7468ef3"},
+    {file = "pyats.aereport-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:6a4425ef37a75858730b9c2942295a1bf0f104ed73ae45aee560415d4a0b73c1"},
+    {file = "pyats.aereport-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:418cefb671e72e1d32c25cf575e18c5c8686015134d983618cc1c7be09ee3b96"},
+    {file = "pyats.aereport-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1a0a9c006806a9279b3541d6220fe11968c2841059f7bda1c14f8a65d1297b27"},
+    {file = "pyats.aereport-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:990b1a18848d0b5a8f5d9f407ddc3e314749b0141df02eabc2a5bc6051024e71"},
+    {file = "pyats.aereport-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:487ebb27644fbeb153ffbbe70ca513026065226fd515c3c324d4980edd4cc73f"},
+    {file = "pyats.aereport-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:c2826a23b858c5b5e68507811ee33fadc90dcc856d890a7362379739d7dbece2"},
+    {file = "pyats.aereport-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:2f255afde045743f3cf3799d7b4c54b89e2b4433c187583ce6d0f6bac286df9c"},
+    {file = "pyats.aereport-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:680da0a7e0ab61bd80488d4f36f03e9489dbe945a6ca7b5144deabb201b0c52b"},
+    {file = "pyats.aereport-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:195f970b066dc38308b42c6157021ab5d2255abaad3befeae881e89e7d70e1ca"},
 ]
 
 [package.dependencies]
 jinja2 = "*"
 junit-xml = "*"
 psutil = "*"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.results" = ">=24.2.0,<24.3.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.results" = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-aetest"
-version = "24.2"
+version = "24.5"
 description = "pyATS AEtest: Testscript Engine"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.aetest-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:5cca0a64384eaa951df40f795c1efba391f522bcb4d2300ac8266f421d8788b8"},
-    {file = "pyats.aetest-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:99082b698816638f450bff07d43e787abd705f0f77afa06771792e216db339fd"},
-    {file = "pyats.aetest-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:3f511d2510fb7a5f16c13623811f123ff4a71820b87c919543254da784007f46"},
-    {file = "pyats.aetest-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:1a6b8f086c1141d8e96f9d9c3991663724f2e97648194b91c0a6f38f6be45805"},
-    {file = "pyats.aetest-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:016850929dcd480f6d18a0f509cd484cac993acee7b0ea93f212900584802554"},
-    {file = "pyats.aetest-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:f7c062e99e6873822ed40ee94141faa9f25f0b401c51395071f186e7b590b6b5"},
-    {file = "pyats.aetest-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac0c77e9fb76bf8ef29023aa83686aadca79159b6a76d60863f0017ed91184a2"},
-    {file = "pyats.aetest-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:3ac9ce849f61f8487f3c90befaea7df46de5fff10cce8bfc508296bcbfb19756"},
-    {file = "pyats.aetest-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:ab91937c974259db62c950a5fb397f9bcdce2b3defa09beef656ad88b3879e7e"},
-    {file = "pyats.aetest-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:06a0ed2f85f61f7af55d20026e397a3388eed902815e3ee1cf2f47c7e6bcff63"},
-    {file = "pyats.aetest-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:98854641ec4bda01f4ecd3f420eb40d5ac94bdc1fae7feaf6c8638278270aa0f"},
-    {file = "pyats.aetest-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:7b006786689de11a0ab521b12cb89bb2fd3652bafa4578102358f9a2abf9f297"},
-    {file = "pyats.aetest-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:5d95953aefed60d7c210b9d6a2921157944143a67cc786384eec1454a8359f4f"},
-    {file = "pyats.aetest-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1bf2967762b791d4eca1880e58d62756717eea9a692a0b5b0b7a62b049437023"},
-    {file = "pyats.aetest-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f0cb5e7dcc28911ca112060c16153d8d5a63797927c7a5cf94d2c0e5471fcb49"},
-    {file = "pyats.aetest-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:df24a3cbdf9c95735572a68e0032f12b4ba92d8c0b7b48b57f676841c0eb839e"},
+    {file = "pyats.aetest-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:bc710e2648a39356b984315e3f680e724a7d165b9746e9f0b7d4ba3ddc64fbd9"},
+    {file = "pyats.aetest-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:45045ce830c269e3d64db9d47fcff28f956c6d1cd1e614976b8183de52690c49"},
+    {file = "pyats.aetest-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:ac664bba8fa57a5039be9b9294f771e5da737e6e9fa0c27c916dc4fb82c03ac8"},
+    {file = "pyats.aetest-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:34c12031b50a62ce07af5742aff2c521a6b58b53e84cd5a12bf63a3ee8331c41"},
+    {file = "pyats.aetest-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:3edf5c0ebef921a617b016fe530cd0176d99ca87c2826d7beafb85d363ff985c"},
+    {file = "pyats.aetest-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:cceb3c2d33ac1ee681de2ed8fcd94426d795e8fd3fb6f5667c35fbf601d12457"},
+    {file = "pyats.aetest-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:5f8af7fc91515e657d8f992d1223ec87b633ecaac58d2489aa5565223d484cc5"},
+    {file = "pyats.aetest-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:b1b0272a4c84e964b7e46b080b171eec5b226927dbee217d4cc2f6975bb5890c"},
+    {file = "pyats.aetest-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:98a2233c8f559f0a389b4408722e325f6939622223fc030f9d2b10f38a8c9e1a"},
+    {file = "pyats.aetest-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:39b0453f425d0f50a46571db22b51f90fe68893b6c87d6e23bc4c9f880e1e119"},
+    {file = "pyats.aetest-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3f03f40c0e38f8f8f99dae47b37f825b18e60ed9987e2bf304f3a88a631e97e5"},
+    {file = "pyats.aetest-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:138d2ccb427267899fc9d724e18ac60753164f60e597fa4abb3946fe3e67cdd6"},
+    {file = "pyats.aetest-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:cca5ebd604170b4f7142b44f87925412ebca3ffb86d3f68d08d092bc09958e2e"},
+    {file = "pyats.aetest-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:a74cc2cfdeca753de98b88c29232825eb6c2ca504aab29f436cb58e7c95de910"},
+    {file = "pyats.aetest-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1e9fe01218a7e4d9b67a0616e01ab3ff7bb19dde83de9e44b483881fdb03f12d"},
 ]
 
 [package.dependencies]
 jinja2 = "*"
 prettytable = "*"
-"pyats.aereport" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.results" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.aereport" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.results" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 pyyaml = "*"
 
 [package.extras]
@@ -1416,91 +1413,88 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-async"
-version = "24.2"
+version = "24.5"
 description = "pyATS Async: Asynchronous Execution of Codes"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.async-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:85a208ffd2141cfe590d50cf46d63b2ed214c35a04d6220a452db6d95bc0145b"},
-    {file = "pyats.async-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:08ba9c6f69ea7b53e2504d07bd7983bbf47bf23a9c7a20f840943abe02523feb"},
-    {file = "pyats.async-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:b088d2341a3731421027117280006698246a09e37d0a1870e8a3580276cd2669"},
-    {file = "pyats.async-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:883730cf08d88a0e30fcf4f667bec90d1ec3af66cdda5f7b154bd0488b9aea46"},
-    {file = "pyats.async-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:04ba737c6d2412be44d5fbb69ee256d5f4db2755abe5ebf2ab1d215c3f25fe18"},
-    {file = "pyats.async-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:d9887c29e9915023e5213b6fe8746478f740f6bf6020d0207eafc2233e556ab9"},
-    {file = "pyats.async-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3adf48b89add489b29fb594d41a408e8146e75f451aaf0f0edeed1f915a3a2f7"},
-    {file = "pyats.async-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:f2f63bf30d59899d09901d9e846e70d85267370ce318aa2a24c5ea830cbae937"},
-    {file = "pyats.async-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:53bda069e928f50762b4c749945fb2db6b6b8a701204be96ed492a3f6e4cefa0"},
-    {file = "pyats.async-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:acf324c0bda759f01d3b7a98f634ba209592cc395486f6c5e8dbda847d0eeef4"},
-    {file = "pyats.async-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:bd3a089a7219d3d0dfd3683d496806340bcd9658d80d18daf2628f4b393ff0e3"},
-    {file = "pyats.async-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:cc0d07179fb789fd68280f8e464fd7496817a4bc6dffc81258badd309f92221b"},
-    {file = "pyats.async-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:755fbcc0325f868b7aa2a07f83ba23dc4b867b122509ec82ee14184a0572388e"},
-    {file = "pyats.async-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:76127c17ce56b11e13ab8314a30ade94a9b863db0ecc168f3f249e9c6265beee"},
-    {file = "pyats.async-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:3c17b8d694515b98950b0838bbc2c83a8bfab2211ec19c5329b28d7bbc87b590"},
-    {file = "pyats.async-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cb2c5129585b2d580a7f2aeccf31ddcaa400ca7c3b9df4e6b55e61450d4d8de6"},
+    {file = "pyats.async-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:d9ddd78a373dc08366bca67417f9719a967fab5230378b04323a2fde3102f65e"},
+    {file = "pyats.async-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:86290ce9b1109ac8e66a507c94cb2d3d1c2643fb1f842ba266b81b27a07eb733"},
+    {file = "pyats.async-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e3b8f03719a8e21fe84d6121cd9ebb707f1329981cd075feeb68dd7e0897944e"},
+    {file = "pyats.async-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ac8963bc21ad49753b584acc541e0f9022cb1c1847fb0411ac39716d7a8fd55a"},
+    {file = "pyats.async-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:98bb4d685a4de6c53e63b6f78ccc98fb8240bfd77468cce33aff220a7dd01a80"},
+    {file = "pyats.async-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:46c416d59ce0b6c7ee631387b5a08885493381ed47d157d0d549c63df8c9ecab"},
+    {file = "pyats.async-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:380abfdaa1be7b7293efe6e4e74111fc414298c2a1048bab57f0c4b4a5b68782"},
+    {file = "pyats.async-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:9d1c51ba4baf0c87f51e3f76a50e64f6357f7de05e683d560b7945a1a621633e"},
+    {file = "pyats.async-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:e03a9b95febb9341fe90540ad3e1a8a9de1560db4c638e4caa920c62ffc4fc7b"},
+    {file = "pyats.async-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8413e9e55ba7671aeb8aa13ae6ae78697a13d0a945fd09e66fc7b1ef303201d2"},
+    {file = "pyats.async-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:2cd9fc61af2c601c65908c1fd993d452d1b9fa98c28e0cf43c71baf44fafba0b"},
+    {file = "pyats.async-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:eea1bdfed59eb1ea591fd7e2f3749992916be6756df517545391b088159e436d"},
+    {file = "pyats.async-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c488bd83d9f81ba08a281cae7c6eba46394245737b9e6ad92e2bb39035274b55"},
+    {file = "pyats.async-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:73244a239cb7e118803f63275f7de0f2b64253a9bcd8de772f23e347f5c2c08a"},
+    {file = "pyats.async-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:940b9730a03819d815ae01457004f56e8793635e2dc9ecb1371bdfc374c0eb30"},
 ]
 
 [package.dependencies]
-"pyats.log" = ">=24.2.0,<24.3.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-connections"
-version = "24.2"
+version = "24.5"
 description = "pyATS Connection: Device Connection Handling & Base Classes"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.connections-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:5255cf69699b7eba15471679178a7f40911fb83aa0796f542c9971dcfb02e120"},
-    {file = "pyats.connections-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:71fca441673cb31264654dfc4b517d60105c1b9a240780fe3ea1c16223d56b98"},
-    {file = "pyats.connections-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:d06645535935e3dde9e05454ae4fa7dfa0a7f35741798445cb42b705e5769ed6"},
-    {file = "pyats.connections-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:95aa8099c10a58abcfd5260063c8e9f10e59ee72f82e5766f29ad139b1f156ff"},
-    {file = "pyats.connections-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:b328e2e08a8a04a27d066076821608b80785a8ce4fe7a859740b5898bc00fb6f"},
-    {file = "pyats.connections-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:94185de6b5e25f0092040ce7ccb63b481ebc0e6c70ceb0cd4f9f275f2e29a66b"},
-    {file = "pyats.connections-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:010caa0d1a732c4fd2cb894e45ec900f39c8bf85ca95bcfb7c72cdac27add3c2"},
-    {file = "pyats.connections-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:1541208db3a2aaf1d3f2b26dd103ccf1452191ce276be877f4bda86d22d23e4c"},
-    {file = "pyats.connections-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:309436c9485470cff57094168b74eaff33e4845c7339f5ce628a309b2f1595ed"},
-    {file = "pyats.connections-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a26cd171a7f6ec34be3cb59ad9699477879b04d767083a3b50753e5c04b507cc"},
-    {file = "pyats.connections-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:44e6c831a306aa1a94dad7ab26ff6e14892efcab9a882e31070b9aac2df81449"},
-    {file = "pyats.connections-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:f9b4497dcf3b4feb9693785c7c1950af3ac149671a5926fc3f3cc6ffd000e968"},
-    {file = "pyats.connections-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:258b73c66c74baac98a0c17064f27660dd678b79c12b402efd5215c2ce318608"},
-    {file = "pyats.connections-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:e7abf433b23ddee6d6bdb03dcddadc2c825cbeee7767ae2758f020eaef87cc48"},
-    {file = "pyats.connections-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b8cfa3a1ef1d608f1b7b30c076c1e86784956587cecc5e286360aaa23cb647a1"},
-    {file = "pyats.connections-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f49d41f030df0404781b0442ad6dcc246e373af8b81619b6d32621eb456cfdf4"},
+    {file = "pyats.connections-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9b0b663d19f416faade05aa97a4f647c51a78c673bf2ea47dcdb51d242d4ce7d"},
+    {file = "pyats.connections-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:97687771fe31145972248143cd4dd08e45b5506b22ccb0c7e14a1a99e45f6060"},
+    {file = "pyats.connections-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1a606a526ac5203c663f6bfbd244c934e096e7ac2627dee441c097ac6920335a"},
+    {file = "pyats.connections-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:7d32b00f240287d56619f0a20e825a1ef26015449dd8af291d92701b9ddd3c26"},
+    {file = "pyats.connections-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:363694712d1c689ed07f2b0e72ebb3b0cce222dbd89ee5bd473640355c5e08c9"},
+    {file = "pyats.connections-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:6e1ff796809518a0549660b4eaf7a6d717b98f169e6579fab2aa62119c16eb4d"},
+    {file = "pyats.connections-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:97e8aac9d4fc38f0d95a4a7ac4c9523dd36168b0d0bbb95b131cc13d5eed2e38"},
+    {file = "pyats.connections-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:6c996dada8b6cd756f7fccb163d276b82ce8b404c19df7c7e5a5bdcdefe5e985"},
+    {file = "pyats.connections-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:683cb03b894cdef4e59206301120126273407b0ed5e8a174baae226e7726ecc7"},
+    {file = "pyats.connections-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:ffffdadef266bd07cef322a1502f8be07caa89c26dd21d5f1b54337025f594e3"},
+    {file = "pyats.connections-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:eef34e881d79434a851f0f96382251954d5c0c6737c0393186a2c7c8ae3d5aa6"},
+    {file = "pyats.connections-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:89ee02f952d905f97903475847c6ebb2b017700c8f689afc0cce8ea5eb7aafd5"},
+    {file = "pyats.connections-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:a717afa51c068a0751446abd9d2c9e0b208d51177c34f3d366df3b7b9982e9b7"},
+    {file = "pyats.connections-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:d09de1a4f68428cb2d5dcc2d931151d90b3b94f27ee3655b7eef8c603ea0d760"},
+    {file = "pyats.connections-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:dc5c9fd8a0c8f4058ee2c532046d5076c401a31fa0638ff367478cb93da1064d"},
 ]
 
 [package.dependencies]
-"pyats.async" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-unicon = ">=24.2.0,<24.3.0"
+"pyats.async" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+unicon = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-datastructures"
-version = "24.2"
+version = "24.5"
 description = "pyATS Datastructures: Extended Datastructures for Grownups"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.datastructures-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1d28a9f02f16ba5c653ea8935b5e818755c8a4e3a25eaf55904c380db3e3aa1d"},
-    {file = "pyats.datastructures-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:e3c26524f95e5b3138edc9446c8db3a772f599fe83e1344d7a3501244749f7f6"},
-    {file = "pyats.datastructures-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:319c0bb8c983c97cd8657f62a01f21ecabc9f8e93c775d039950966dc64c053b"},
-    {file = "pyats.datastructures-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:72008c3aad7cd8c84d8d8caedd99f3b805d85a7f7a107be3e771a95c69e4df60"},
-    {file = "pyats.datastructures-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:1c34d99e961c9d0a9feb14308061b0fb39aa0afe69b0dc3f7afd6ad798df6acc"},
-    {file = "pyats.datastructures-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:4f81d05b8bee5287293a6375880aa198eacc02a1d6ce70aa47b7b5542e12e94b"},
-    {file = "pyats.datastructures-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4efdf14d8e1f5cea3517dd1b016a385fe1783ff2a62cec8acd76055b632483b6"},
-    {file = "pyats.datastructures-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:129ab87923b513ff58a853f7fb29a9f99b41450e70aed6084dde5948f16147c8"},
-    {file = "pyats.datastructures-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:64e93af573762b1c96960826d3aa64ad195e7b5dc286678b1830f26b6442e024"},
-    {file = "pyats.datastructures-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a935a9244e02395ec3eb623cf77cd734b598b4e5b20a91f353d702b0224c78b5"},
-    {file = "pyats.datastructures-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f77d59b74ac85e3bce1b194f607b035bc36bebb9321334247fc1786fe3f87f48"},
-    {file = "pyats.datastructures-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3d3e9e5e079015eba13a1ba16c9d419eacc50041aa49b95c1f1d954f33393039"},
-    {file = "pyats.datastructures-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:c22ba35b3d754c70d9d0f5acfe3d1aac29d4fb8623b4e67f01faae020376e8d2"},
-    {file = "pyats.datastructures-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:74bb2198602b33fa8288beb01cda4b3a4c2086c03032548ef68c5470af68142e"},
-    {file = "pyats.datastructures-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b7ff2e51916ccd08fc96c3a8e30e0bc085782733652fd563eb3df0f2ad462078"},
-    {file = "pyats.datastructures-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:325b9317e88aeca0e2ee0018f6eb6f2a6a6540224b66de40b2037d38eb6d6a9d"},
+    {file = "pyats.datastructures-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:db255ed96f30f5013a883b3216ba18d1380e18367c42b2afa8f6e2f0ca0d5829"},
+    {file = "pyats.datastructures-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:7001e549dd082f9e249099af7ee1b9046ff53a564bfa03d9875c3ed55f12cb6f"},
+    {file = "pyats.datastructures-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:1580ebc16dd72d6757975d5fc5a86611d17330fa1922e59641858919d9a3c4f1"},
+    {file = "pyats.datastructures-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5e269338229220e02b079d132255d2365b7968c81e15d8e2f4e0736244f57bdc"},
+    {file = "pyats.datastructures-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:2312336cf7f0bcdbaf963e470e5f415c3a2fbaf70c89693b945757938a40b823"},
+    {file = "pyats.datastructures-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:d9b3f42a83396145bb3683c61dc71d20c0e4982573c838546901564ec99f31b7"},
+    {file = "pyats.datastructures-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8e7847f8c6e4e99f1e7df60f88d0da44a05e34282e737d25a540a7dadfab4ea7"},
+    {file = "pyats.datastructures-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:89b63a39dbef44751986446179761bd4ea0de277118ef1b65a370993e0dd11d9"},
+    {file = "pyats.datastructures-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:c5c01e6110e39c7c3e1f24c80d9a1bbf95c94ed3149dd6085a1c9089613cb6c8"},
+    {file = "pyats.datastructures-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a885c90840ac84702f7a9ce0fe95f4d6916e0a3677d1423646c84d3f847320c8"},
+    {file = "pyats.datastructures-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3bfc37b4d05822c6c6b2217256b0e654dd8aff9c81b67b2c8b9d7fbfb71c733a"},
+    {file = "pyats.datastructures-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:1791911919678b7b407c3e0f5678de620a7685776263a42df25e2e6978448abd"},
+    {file = "pyats.datastructures-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:fa0bb568934881f0a497455fc0b0209b4e3bf9d1087229a4908782b45b22d2d9"},
+    {file = "pyats.datastructures-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b348ac0ed136d54a63c36996cff868330482f3580f1bb1b6e49df3ae5cd2594f"},
+    {file = "pyats.datastructures-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:59dce260ba23f62921cc82dfeec74cb4366c0a066446b7b7aaff01af1f87f465"},
 ]
 
 [package.extras]
@@ -1508,40 +1502,39 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-easypy"
-version = "24.2"
+version = "24.5"
 description = "pyATS Easypy: launcher and runtime environment"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.easypy-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:2ac1aac907c06171ea684796713625ea8c970873679689ff577ebc74945a1560"},
-    {file = "pyats.easypy-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:1ee49720334ecc0052a9a7b56a1c8480e266a7a04290fea450b92b53875c28e2"},
-    {file = "pyats.easypy-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:ab81155d15707740d582f67fc0f0b46601c11832a69de624bf0473a9b73b848b"},
-    {file = "pyats.easypy-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:64af74c45feafca3184dda81ec2f3357ed7cc8e230a665c63a08f21333e67ffe"},
-    {file = "pyats.easypy-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:11941f743a10b04d2a39835e1a74324efce4ffb88b46e7bc5dc6399edba339ea"},
-    {file = "pyats.easypy-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:0f50d2c356705328f9239be15cef354afb17e9cfe5254fde9930b4de042db8dd"},
-    {file = "pyats.easypy-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:cb65be32eaca6a62040b114117621d74f0a5a5359078b8f39a5486a5b2174f76"},
-    {file = "pyats.easypy-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:97a5b4a29457bb35adaaaa09f147304e4c4ae43a57d07fe2bd9d3a6089654c27"},
-    {file = "pyats.easypy-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:7ccf918658889601dad7daaab818def4900bf27ef8fdb6a1a17fa4010975f54e"},
-    {file = "pyats.easypy-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:861ee699f094a521e649ebfa2b8dcb4cbdc5525f0c7356163a0e0d779c9086c2"},
-    {file = "pyats.easypy-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:c47b5e58a045dd9a60b84d485dc3c44ca03748a7f313f26d4d072c2328c569b4"},
-    {file = "pyats.easypy-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:04b6bc7fee0fe56810e7fcde0f94f8d9b6740efc2de81cc17ac1f608c03e64ab"},
-    {file = "pyats.easypy-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:6d3722be9365f31155aa875433c8d60ff7e4166250273edda67a5e562c79f72f"},
-    {file = "pyats.easypy-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b7eb2a4bc1ec39ff4db8dd6faa677c52e746b9de588ed9ac5fd560983c5a784e"},
-    {file = "pyats.easypy-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:61f07c7fca89e7c57f0046026e358cd5a6f70702b3807f619491ce217bedd20b"},
-    {file = "pyats.easypy-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b7ff4a4e8fb1577427f0c5b1187439c05776643e4059c4d4239570342b442578"},
+    {file = "pyats.easypy-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:3aeaa34a9b81603f4e1b6d4338a7cbee0c3e89b8d6793e9d85c0bc73621ce7ef"},
+    {file = "pyats.easypy-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4fddec5884924c8a0453f0d158be3ecd9b243ba26f17a1313e59d81e993616a7"},
+    {file = "pyats.easypy-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4674baa749d14e31926695ab802829b12bd0ce2557b3ee60a8be1bbd368b4fdd"},
+    {file = "pyats.easypy-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:f428e48287943bd9f315b4156fccaa9683fb2caa7be1d6130e9cfe18b7cb4c99"},
+    {file = "pyats.easypy-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:4ff697f62ba6319a11b93d4acce8d7389c6f598477becedd9fc2dd458004f015"},
+    {file = "pyats.easypy-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:a44ce832c14882d787c885f1f5c6262c3f7735a4bd838562d81165ebe26b79db"},
+    {file = "pyats.easypy-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:36306e80664468f3a8f398a804416e8e484019a1733b892b6ec52af90f3c5378"},
+    {file = "pyats.easypy-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:b83814585f43417211d803a2a6286e4f5f83b5fcfa89689c4101efbf4c219d88"},
+    {file = "pyats.easypy-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:19f85550f921b61d784a08df22d7ee678c992f16b8c88e3a6d61804bc0161947"},
+    {file = "pyats.easypy-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:615c8b81e536add526ff57d82fd8e88d282191614aab36a0f9479b7622569a9c"},
+    {file = "pyats.easypy-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0e531be28a1239b5a19825eaa0d97eb9b04a992fe52d302919f5c7212eb7f21b"},
+    {file = "pyats.easypy-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:957471557a7dbc55771bd4341f41af1ae2e3d6d7ebba03c17c36dfd3a84daedd"},
+    {file = "pyats.easypy-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d13fbd7ce7bc5bd2386b4ed54b2c59bbaa57340b17c5e7b8312ea813891f7935"},
+    {file = "pyats.easypy-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:010deb46fcc4afc7f8febd6742d66629e7af266560cc8c766e189f8d2f938150"},
+    {file = "pyats.easypy-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0ffa9208296a89b77242299ff716d765a12dc669dcc1e3ad989e271d59aa940b"},
 ]
 
 [package.dependencies]
 distro = "*"
 jinja2 = "*"
 psutil = "*"
-"pyats.aereport" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.kleenex" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.results" = ">=24.2.0,<24.3.0"
-"pyats.topology" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.aereport" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.kleenex" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.results" = ">=24.5.0,<24.6.0"
+"pyats.topology" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 setuptools = "*"
 
 [package.extras]
@@ -1549,37 +1542,36 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-kleenex"
-version = "24.2"
+version = "24.5"
 description = "pyATS Kleenex: Testbed Preparation, Clean & Finalization"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.kleenex-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:a9b4ae73c64e3325c94c6c2d3b8e2e42f9ca7c54caec8a326b1d34cdd58eb75e"},
-    {file = "pyats.kleenex-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:4f30cedf968408f998efd8eb975c230e72b990eb6e4376baf4dc11f0ca38e778"},
-    {file = "pyats.kleenex-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4057552322ec1ede7dcb67e2332de7c9fb7e0c6cbcf3cc07f73df182ec957493"},
-    {file = "pyats.kleenex-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:7942087e752df14fba969f34b71dc1967d8eed4e7e0e70e6cd7ffa4a67f61eb1"},
-    {file = "pyats.kleenex-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:ff771f2d1c6f02330ecf391f144bb6c6b4b5c2fbf2020bc89f1dea2a660e0548"},
-    {file = "pyats.kleenex-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:91e5f82d0f60b9627675ec6aba6b5a5dc47feb652df99ca516fd66932be60ac7"},
-    {file = "pyats.kleenex-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2e448cb66d6f574314652bf1f32e98a482c235fa5ff2577074bd4e3ba68ffc0b"},
-    {file = "pyats.kleenex-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:e31285efa08627683006e15649bb3f928ad4e399561286f6dbf5f1f327722331"},
-    {file = "pyats.kleenex-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:c70045576de1bd27fbc458ea6ecf5862957f996c96fd3f732001580acb498106"},
-    {file = "pyats.kleenex-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:1f584a64a18823c0a45d8be20710a40033cf3ef07fab03afed54d8d00898c72a"},
-    {file = "pyats.kleenex-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f34620fc199c918c7cf340ca6386b383a19df999ec07e0f970011be1bee84a22"},
-    {file = "pyats.kleenex-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:e92c75fe9db130e816b9999d7cc2236bfabab9e65d29cd81096845f01723a681"},
-    {file = "pyats.kleenex-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:ad2016c2ea2ce6d3dd576b403b212471dab8de549c702b660541e57465b18a67"},
-    {file = "pyats.kleenex-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f7267636009f6fad2e06550d1e9f3c9dbd3ad5a484a62dbee6d5a980e07336a5"},
-    {file = "pyats.kleenex-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:a7ba75efc0beb9e13e18773ad3d2fce21dca40d511e6abced4dfb2b82e977d12"},
-    {file = "pyats.kleenex-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:14f66c2d8c1a592fcb0fec00035432f9de59052096a4d4d615716c985b82695d"},
+    {file = "pyats.kleenex-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:89cfc2eeba71a150abc89e33cc9b17d653003eebd772eee3fe5405cef59ec3d4"},
+    {file = "pyats.kleenex-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8ada805ae74d7adab791f32b5bd5719674d310662e75347844a3e6f0652d5aed"},
+    {file = "pyats.kleenex-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:17c45c34cc0ea713de66285c378ec7ca149fd30eb3ec707b60ea329b0b2d7264"},
+    {file = "pyats.kleenex-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e48c841293e50e877c7dd80eb9e34dcf9dbbac0958027678562059b61217910f"},
+    {file = "pyats.kleenex-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:0bd176619ea8b5301c934a0a085a18ad22d5b48422048f116beddb040ceda3df"},
+    {file = "pyats.kleenex-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:2ae61c87cf2f854a4d01b028964bf298d432bd140a21860ac25e826da068b378"},
+    {file = "pyats.kleenex-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:9b829075c88c69f892a03cd5fc766a858c238026f2576f4c86dd01d2ad64a12d"},
+    {file = "pyats.kleenex-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:60420be2e8281f0d3fa8c35385764fd720ed2a38b86d736df62e7c6653cb6276"},
+    {file = "pyats.kleenex-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:a2d48f91de66af2bae99fe933e2391c63f9066c4d2f9269f6890b3adfae79377"},
+    {file = "pyats.kleenex-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f2e52d30670868e45afc13ed6cec50418b4c7432026d38a0cc004de810b257ca"},
+    {file = "pyats.kleenex-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:d0286722d714929a4a3f09d93d6cc1f5c598b6422068fd18f8cbeb800982fcb1"},
+    {file = "pyats.kleenex-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:0c1eb96bbcada0cc3646e72a0a6e496a2b19463a406c245746ef6d70f74af90e"},
+    {file = "pyats.kleenex-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:70b320a641b42a3d5a953f9eca11ffb78274a03f019ee9c156dcd4ed1ee40438"},
+    {file = "pyats.kleenex-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:decd25c0f020f75dce0ac1425ece63b300d1356c6a2213fd8064fd54d26b01de"},
+    {file = "pyats.kleenex-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7aaa02b79583802c8b3ec74a69183715ba04bbce3a1f6bb6766afc46c6d6d443"},
 ]
 
 [package.dependencies]
 distro = "*"
-"pyats.aetest" = ">=24.2.0,<24.3.0"
-"pyats.async" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.topology" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.aetest" = ">=24.5.0,<24.6.0"
+"pyats.async" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.topology" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 requests = "*"
 
 [package.extras]
@@ -1587,27 +1579,26 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-log"
-version = "24.2"
+version = "24.5"
 description = "pyATS Log: Logging Format and Utilities"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.log-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:b0ae03cd46c231b160bdd9ec7c30035c856017e9ea50d9af127a6d51c4323495"},
-    {file = "pyats.log-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:ff87f6e7c1c7d2080025bb8025d0dd8aacf6e0181b8bdd5eea3c59f25eba3c68"},
-    {file = "pyats.log-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:bf035d843c13c13d967d58aef195eecd82aec38d91404a02812f5799ce9c516f"},
-    {file = "pyats.log-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a811243774f79429a7238650bfeac0103ee51ce8b8097e1bda35212397469129"},
-    {file = "pyats.log-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:350c4cabb09c04752b51fd5b8865e9d0279dcb7f549492da7613b3d590f7e125"},
-    {file = "pyats.log-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:3b822f3eb69c9dae674b5b9faecdc1273ed1e728eb17f4a27b77c31da0550cbd"},
-    {file = "pyats.log-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:96163a9ed53345743b497bbfcc0f09981cca9401b1b5079e5659ec118a66464f"},
-    {file = "pyats.log-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:e1e341591f94a9c4d3718a28720c70c11a237b0f986128a2223b442b6a808d05"},
-    {file = "pyats.log-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:cc382b28b26ee1eb1188ded58ac837f2ef975982eeb7be9bac0fbac2d670c147"},
-    {file = "pyats.log-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:56555e039200d8c5ba52abdcf062230524e7c531a5263a180277414946a9cfd7"},
-    {file = "pyats.log-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:3a018cb4941408f8a34b956c47f6052f66adb463172190e019b866c049daa9c5"},
-    {file = "pyats.log-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ebb954bef71d7bdb3bd39c40203cd690174f7a64c6551c2e4c768614b9bc3558"},
-    {file = "pyats.log-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:d7c12ff22a2aed2726313c28383e56ca437dc31efdb22b92dddb329133bd2a25"},
-    {file = "pyats.log-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c9d84b1af188dda479a23fc9be1baa8647397df2bdd7d6b19b966b36e65aaec9"},
-    {file = "pyats.log-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f3440cd6dfe852ab215193be0b6b49059c7544f793f2330a2eb09e44c0087347"},
-    {file = "pyats.log-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a1379f4618815c6667482c4b22aea5a4819182e80c62f1093306af48351da7c2"},
+    {file = "pyats.log-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:036f6adf4cb6a7c52e8e5d052694ecbaff75f25952c17263d42defe3b9e5ef85"},
+    {file = "pyats.log-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:7aa218e563bb5837809516762f9c7d8fc15ef2d044d3c1c1294b332ddb874b27"},
+    {file = "pyats.log-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:b5bc4e422b59df88f309c92388b04cd6219f99f6a9a64e855a80030558df5d88"},
+    {file = "pyats.log-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d94b35bb92b55f6ad4d6874376096192ac89ed60e12eb81fe74f8c9c958d92ca"},
+    {file = "pyats.log-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:48768038ec09f3e681ff5d40a0d0227f06322095237072f105afb59a4b0cf532"},
+    {file = "pyats.log-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:f563e091b37e2a33f27e41a004aebf028d490c57a6cce55bc71e44df45a48fb5"},
+    {file = "pyats.log-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:6aa80b1a3d83c808cd181121a3fdcba243d5e3481f3698165cca8434ebbef203"},
+    {file = "pyats.log-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:fbf3456f634da08d9407da8a517d31d3833938dcde17a3417ec5fb1a527931ea"},
+    {file = "pyats.log-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:383dc9dcf11f56467216bb744548021b602973f0e27d10ab89d2d360d543401f"},
+    {file = "pyats.log-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:98a039135cf728dede1ac9245945018ddef867936dea7ff5386b3e4d74612750"},
+    {file = "pyats.log-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4a027d495da5332319e59822aaf1f35bd6a6c9d8d195256713a8af32eb024824"},
+    {file = "pyats.log-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:82f62a351d94c02afd582f32553fcbdb15ffc5e79535560079356cb6d8df58c3"},
+    {file = "pyats.log-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:bf690dc8f89214d6d262a77efce3c2d63d80c0f21bc4e09f13439bb245c7ebf1"},
+    {file = "pyats.log-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:436ae8c5cacfe750ce66ed2ddb23ceb75f2a601c2c6b9d1cd0ebfd93e784433d"},
+    {file = "pyats.log-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:d90f6715c11c147305b24e6a0113a9e6f5f1e4cf1b739509f4de74aa43b492d7"},
 ]
 
 [package.dependencies]
@@ -1616,7 +1607,7 @@ aiohttp = {version = "<4.0", markers = "python_version >= \"3.6\""}
 async-lru = ">=1.0.2"
 chardet = ">=3.0.4,<5.0.0"
 jinja2 = "*"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
 python-engineio = ">=3.13.0,<4.0.0"
 python-socketio = ">=4.2.0,<5.0.0"
 pyyaml = "*"
@@ -1626,35 +1617,34 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-reporter"
-version = "24.2"
+version = "24.5"
 description = "pyATS Reporter: Result Collection and Reporting"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.reporter-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:299be3af83cf1c58e0003f12587248c1d1be5aec11be512e82f9d707490afbca"},
-    {file = "pyats.reporter-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:3c0ed7cb280b2a36b717986d952336be83d99b540f5f5b867ecce7316a072a5e"},
-    {file = "pyats.reporter-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4dbae1944a4174a193cfe4d9640e30a412947745cb0f7d365bfad4ebe0b3305f"},
-    {file = "pyats.reporter-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:efdf56c5514442c5a9f4d0d32ba426eb5912a23fc269d30838f63397ea8b9d50"},
-    {file = "pyats.reporter-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:cf50c13d9744622195b853f39d1d053dab6b58e38649da59dbad9a357a382c31"},
-    {file = "pyats.reporter-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:3a551c7dec12cdef6b54ad64d68110c43ec226d0b32571658837be82fd2b5366"},
-    {file = "pyats.reporter-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:69123b75f5b6967b976cb6db6d5ecbfaacc4c48c11316edea665a5ff407b9473"},
-    {file = "pyats.reporter-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:e27798566078b3aeb39fda9bdf3927e599bbf6ef38633487328ad71cf5d1a3a4"},
-    {file = "pyats.reporter-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:b1189e73072f71a14410ab8fad18e41fd921bfd11a1215d536357c88047fb55f"},
-    {file = "pyats.reporter-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:caa9190a7205b49cca641761515ea40146186bd2bcb11252177aab7c38440430"},
-    {file = "pyats.reporter-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2f490a5ef34f7e66567c801b173fd4ba6f227816c84019fb0a8b2cc2a0596467"},
-    {file = "pyats.reporter-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:30a6d9dabdd6a39e5bca11d8124b8499b30b5fb273f691ece7d00c1a021a3dc6"},
-    {file = "pyats.reporter-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:887ebb5b38339b1efa5b4d9956fbb402257a6e23a8bd15f1864f3617042b59d3"},
-    {file = "pyats.reporter-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1b2c1bda0476a69d25cf7f0cb91e27f1adc957fe6e04381467f548f03a23350f"},
-    {file = "pyats.reporter-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c57fa1d6674531b41ad1fc7523e70eb37145c8087f0a2ed3fd5307ab3f9a0696"},
-    {file = "pyats.reporter-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:80f8e78c0b454c5f2ed7cfd168c55e0bfd3fc4d0b4e214651241f7c6b0dbc77f"},
+    {file = "pyats.reporter-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8115d3c92744e84d9a7ac03110bc6c3b9e23d70f33f77ed126d44739de9965d0"},
+    {file = "pyats.reporter-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:06dc7b3f4fa5a394441a4d71bdd83972511633b49a94f9f9cd045aeab2972722"},
+    {file = "pyats.reporter-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:04d4f10f0c3a9889fbc696368fc86ffcb8eedece63e70dcbdc8c9975aa3edd23"},
+    {file = "pyats.reporter-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ff8451cb82341669ff8374d2729c27814acf5f5f906950e310a9086f716e4b71"},
+    {file = "pyats.reporter-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:8a8f1c35ad7eb8e183189fe06906e500e41cd4d38ab1291890739fd4d98109f5"},
+    {file = "pyats.reporter-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:7cede57acfc2c644771ab9576907e827ce9012525fd6430b1a8eac60ce138bca"},
+    {file = "pyats.reporter-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:087d37a7ae3f4267e2c8a89b2c28f80257f288fcf5f2228bd7c0bf5d60661362"},
+    {file = "pyats.reporter-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:06c26d40d0adf5f3a3f9b6d7a2afe42c8dcaccf8f5ad995891b9f4a55ac65c8d"},
+    {file = "pyats.reporter-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:3284f5a08931793528aeb8e382170a7281f78a00f272a92a65a0f6cbf4c8289e"},
+    {file = "pyats.reporter-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:825b2669c24f28f6758fc771c3145fa17f58c75af55ed92653f881e738d54fac"},
+    {file = "pyats.reporter-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:b7453c857d00e993f70139618a1e7dd6899c9c877513d39559eb1f131dd404b4"},
+    {file = "pyats.reporter-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:2d911ddd935e749d90b4baefe577858719fe2328fa2c2ac45ead69af904bd83d"},
+    {file = "pyats.reporter-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:561c2b3c95775936605c134d6f88d3bce7d1a882b6c2651863827662f8220d2a"},
+    {file = "pyats.reporter-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ef641e01a23f52ca6bbc6f86b96c37d684a059a9276e1a6cc501cf55232d709c"},
+    {file = "pyats.reporter-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:300de562844aedf6ff4ce3dc0ebaced169670d0bd5179962694ce283078ad51e"},
 ]
 
 [package.dependencies]
 gitpython = "*"
-"pyats.aereport" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
-"pyats.results" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.aereport" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
+"pyats.results" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 pyyaml = "*"
 
 [package.extras]
@@ -1662,27 +1652,26 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-results"
-version = "24.2"
+version = "24.5"
 description = "pyATS Results: Representing Results using Objects"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.results-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7f4cd31beff753682c4a0eea1c31c904c8da45b3934725504116148251084fbe"},
-    {file = "pyats.results-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:b6eaf9ce696cd70b850d4923095d9045278ec688aa348fcac9230e894a428e9c"},
-    {file = "pyats.results-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:bcf36aa94dc0b3f5ed2f2420ddabb5b61df5a776524f7d6069b4e3174dad8107"},
-    {file = "pyats.results-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:2d0e1660dfbcab0d0361046af827b7c5b1e57b4ed0d78231ae9b858c014d26c9"},
-    {file = "pyats.results-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:7885b96460860dd255bbe8508dd01f8f06dcded90194654b68e874e302f68841"},
-    {file = "pyats.results-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:605628d5c4397be4e5498a45be2c7a9d4520b854a43c4ce18d2f7799164325e2"},
-    {file = "pyats.results-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:21fe2772ec75bb236e90bc9446c41bec974ff54418e869ffe7bf200237e36e53"},
-    {file = "pyats.results-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:8536619cc136aa1711cde630d53453050d9a5e91eb7e5a64204cef197697d092"},
-    {file = "pyats.results-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:6b8fb8e8b2f2437a90c00c9d0ee9f1683a5ace031b8ce1c47084f1aa4600d62f"},
-    {file = "pyats.results-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:57e5c237cf6f21511e1d5a53c4112d9330943fee15b40836eb3d1e283e4d2ac9"},
-    {file = "pyats.results-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f1482a770180e6f27325d0660ecd77970844ba7742a4965bd98f6057207e1d5"},
-    {file = "pyats.results-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a4db6fc70fccedb5ca9d4854e8b40d306aa502547467de5943977779da2d970b"},
-    {file = "pyats.results-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:df3d404472f83377fe776fc6962590e525a8ba24f0902acca1c6c7ce55e15c52"},
-    {file = "pyats.results-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b65b213d06b4dee5583b918b325c154b9d07584886864459e2f520f6d2ce59fa"},
-    {file = "pyats.results-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c4b152612ade52b574a727f14aed5f42b29de260715723630d29044900790260"},
-    {file = "pyats.results-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:29307511d729300b0aa156e0deaff4f6cb11ffffa668fad9aec70c6c8c60d3a5"},
+    {file = "pyats.results-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:dca2ec486c06c4e230a1c13148d58a73473b13a815ac355816e617df4b07d952"},
+    {file = "pyats.results-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:db557902fc3de135736c3ffddca486ab1f298014747eaa6c65f548a526a30bd2"},
+    {file = "pyats.results-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:f43cf39ced4fe6e5950afadfda3c9efafe97f60f75696b1237337351afd4f1ee"},
+    {file = "pyats.results-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9741bd236c6002c4e2074f287ae9de808d585296d798b59c7ea1247453000421"},
+    {file = "pyats.results-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:2402c2382ff81d0c2ce576622b7cce5e6e0bad24d7cde32e80dc21e19f343938"},
+    {file = "pyats.results-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:71555c29bed00fcfba188a654488cd69ee7471e527cf7b4395464250955ed4b2"},
+    {file = "pyats.results-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:de3f94288483d9430c1e44bbab46770f3e88f2ba645e39d70b3dbd5745d16b8f"},
+    {file = "pyats.results-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:94fa12c3fc532ac8bf61a4e3f8b520baa774651e3e7b2773c7306313b7962522"},
+    {file = "pyats.results-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:ceb5f0085dda405de1b757f6e09c99d0a2a36a5e4724e8eee0f5aff5d15ef458"},
+    {file = "pyats.results-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:56b25cb6b61c0fcaf5846cf06555cdc08ca8f753b87be69c870a8c918ee7ece2"},
+    {file = "pyats.results-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:2e02a41eb2857c835403639211b556496f3bc3c2ec47b2318ee76d9e29065133"},
+    {file = "pyats.results-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:f057fa611e3723cf4216b33ad5261d69356fafb1e0d2a46c91530ced7291f2f9"},
+    {file = "pyats.results-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:fc625489cf1b5e4e188b3e986688726ab9e3b71789c4ce3e7b8e0072d57f14eb"},
+    {file = "pyats.results-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:e3bac62fee82b692dc0a1b039fdc3121f808b1e639e4d4c854d34e18806c1393"},
+    {file = "pyats.results-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a96b01e4f797e75dd55037c9d7d910139efae02d003dfc2b6256279317e6129b"},
 ]
 
 [package.extras]
@@ -1690,65 +1679,63 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-tcl"
-version = "24.2"
+version = "24.5"
 description = "pyATS Tcl: Tcl Integration and Objects"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.tcl-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1984d0ff00c8a78e931494e12aa21b0c4f6ff49b92c6d348e819fd3ca5d20912"},
-    {file = "pyats.tcl-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:fe7e1f1cc1c085c7bbd31c3463743906f222f358fe4a21a1766718160064ea79"},
-    {file = "pyats.tcl-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:7dab2cf0efafdc4185a3446c75616809b878365930e377cdc6534b86042b399e"},
-    {file = "pyats.tcl-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:5558d4866a1f6dc2c6e7f4785eafea2ff5417c60ef8b72d62f4c81eeb370bf8f"},
-    {file = "pyats.tcl-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5210dc77d94125eb514ad1f1232d487a4f880d10a70a0dfee75bc20ab5ca5e94"},
-    {file = "pyats.tcl-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:dca721db804976565d951a0532ef37da6c89403415f9d2786216999e2709b0e5"},
-    {file = "pyats.tcl-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:9ed228ffc88af3cd16de467e1e6818e36003e2356b3f7d9a10ece0492196edd2"},
-    {file = "pyats.tcl-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:bc6b214420e0b4cd1d61832c75b4d12b26f18cb35f0d963dbe0b3d0494b4e61f"},
-    {file = "pyats.tcl-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:427d3add9c04cf02442f5fb2f1e250f4711b33e0ce678d5d6fe8ab3f40204d45"},
-    {file = "pyats.tcl-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:8e50b3ac0bd6e8f8611e520c23ec76990022f5a7488172c76bbd7df726044869"},
-    {file = "pyats.tcl-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a8a7ad6be24909907469679d95bc78a33d7b29dddae0441dc813fd2a290c0826"},
-    {file = "pyats.tcl-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:0c5720a1db6a60cf9e23eba58ab75729ce15e1d4329f343096b18ac34e8e1783"},
-    {file = "pyats.tcl-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:0b39efa4dc812d8ee470031ba3f6554e99f7feca464365ac647d49dd6e43877f"},
-    {file = "pyats.tcl-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:484d5c3531b12d4090c7924ffee7286b1e09ee4f0aff7b46b503bbdf200989c7"},
-    {file = "pyats.tcl-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:f867958f5a1ee2ccdec744d68b2f14be00df5edc5432fb4ee3140c47b07c17ab"},
-    {file = "pyats.tcl-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a0849cb2e687454d30510036cee45b82188b627139315f6495a36b6b2f785919"},
+    {file = "pyats.tcl-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:1fe2dff6c73dafaef0e99e8812b08879447c3d2d2a7bd7e34c11acf5840408fa"},
+    {file = "pyats.tcl-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d4e9587931d0c378158074fdf8de79ec0ea5246dc75657bffef0f89fc10c490d"},
+    {file = "pyats.tcl-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:7953c830db026be55c7c19da3e6a98a16f18ab802ba86870e84e6e75a973595e"},
+    {file = "pyats.tcl-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:afe87a099ac27b1aef8f1bb1158ad1ee34516a7d94772e2e7986215b92fb5bcd"},
+    {file = "pyats.tcl-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:e7f1d614f6714704bb8aba3aa38c784176f5e99f7c92132e5f51755bdec2e865"},
+    {file = "pyats.tcl-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:c22fbc8cae559402b4751f0972202440bb23db65c114e9e3347852cb0f6c0961"},
+    {file = "pyats.tcl-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:a6ab0025515e1eab5dcf175d35d469d260280947c966a6f436b4a20c930bc027"},
+    {file = "pyats.tcl-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7cce2c10ed3ce6c2abf0542a2f080d1fdde2f1a621190c95d35e9aa0a71d2137"},
+    {file = "pyats.tcl-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:fbd3aa0b5ddc25e6bf2d651f95a6c294695d42c331a1f22eaa107e94e1de9edd"},
+    {file = "pyats.tcl-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:da081735ab006da8d7f27be92d270ced0e62ca62230ebb51b2c01a367ecbd243"},
+    {file = "pyats.tcl-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:41dcdd957b79eb2b78f14ee7ed66e658295d56fcb54e2e58a3361a815733af44"},
+    {file = "pyats.tcl-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:957d371a84cd4ed34fddf25af808f10665dcb251795a68f00007c47b8415bb37"},
+    {file = "pyats.tcl-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c1ff6fae90acc35b785ad2c9bef53120ce5c1421aef0e83126dd076b66223eb3"},
+    {file = "pyats.tcl-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:b315b93a57d731fe124da1260832d9950038b576b1c6c58127fbbcd5c13a9de3"},
+    {file = "pyats.tcl-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2e58419fe3a60dc273b315a25b384374a6b84342e4417b03a07de7d1c1c5d6d1"},
 ]
 
 [package.dependencies]
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.log" = ">=24.2.0,<24.3.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.log" = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-topology"
-version = "24.2"
+version = "24.5"
 description = "pyATS Topology: Topology Objects and Testbed YAMLs"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.topology-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8a5f0e04da3c55755153a33a02425ab2e471c12c8436a19638b17ebf1d6d6d22"},
-    {file = "pyats.topology-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:8f4f354ba45482c7620fac1dc436d1d2b8f398cfa50af91d30eb5a722aadbad4"},
-    {file = "pyats.topology-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:b01daa249b0be00475060906ff151ab964bfdb98cac4ebedcb9ef91e27213e60"},
-    {file = "pyats.topology-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:1fa360380a7c90e1099373b85e87196e68f207ccdb6f16e0a9d790374536e625"},
-    {file = "pyats.topology-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:40d54f058f5fdb59844cd392332b94b8d847fd22eb1ea33b323991c2ee99670e"},
-    {file = "pyats.topology-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:b16db390b5cc005a0e84d2f9496e6f1a51645b9fdb41029a88ca15cbb5e24e63"},
-    {file = "pyats.topology-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2e6788274297d894bd5e98663fb6f24ddfc59047425f74fe40921a559134cccd"},
-    {file = "pyats.topology-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:e2c59947ce9e618747dc2bc4498c97a58f0a86cbd338db677f9f1edbb6530159"},
-    {file = "pyats.topology-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:6ddde730ff98618753aa858d219f42999c9486048e11745982ebff27ce10f660"},
-    {file = "pyats.topology-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:bcfe3c80977652d0a76cd13673b124977baf3e6640bc84bdfee906ba3eb03d5b"},
-    {file = "pyats.topology-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dd219cb75195f46b30d6a75195c88fce6876db185a96a6de9665b0653a30812c"},
-    {file = "pyats.topology-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1b64304b8ed52ebb80b2aed2c403cd6e38d6eba27cdf90af74acf76d7dec3059"},
-    {file = "pyats.topology-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:d583d5ea346957d5a2cda6b26c4de97594ff6990f7c6f9cb7e07074a851f0eb1"},
-    {file = "pyats.topology-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6cc91692e31205192c4dbd1d726380a0bce26bfee1accd4f7d26ef8f68ee94dc"},
-    {file = "pyats.topology-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:080ebedbdf4ca76c1e44317bd87896e359f9d761c84aea0187c46f1c4ccf707d"},
-    {file = "pyats.topology-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:49b6ef9d0f3321f3aa732888e21b2baaecb3d0b7f806bdcafa8de79bc59e339b"},
+    {file = "pyats.topology-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:5ddea1a56c7d081fd5c928232e636fa5252b561e4c3ef20174b941abf3696a33"},
+    {file = "pyats.topology-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:cc06504bd32ba209291bfaf6a3d79225113f0e7783d316b8ef4440866afa6317"},
+    {file = "pyats.topology-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:d4645ed9648c7c1c55b68df284b1e089cdb4b1220478a86514ef06c98ce58a0a"},
+    {file = "pyats.topology-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a7dd631f24e3c40999b770faf8cb75c5ca587dc55ea0526564bae49efcc176db"},
+    {file = "pyats.topology-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:12dccd116f21583fc1dc26d753a557ef293c421c02b2c64bdd3938f230684d78"},
+    {file = "pyats.topology-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:511f67ba8019ae1c8e049f722f5aec9baef8e444e6674361659d11680b18fee5"},
+    {file = "pyats.topology-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:10f0ea999cbfae81f5f080ddf5ea12452d801f6b25cbad21178b076986723624"},
+    {file = "pyats.topology-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:f8e8dd907e98a846abcc12fdb83788a5074f5ee46a8f32f6ffc343589bd8b612"},
+    {file = "pyats.topology-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:951c48f206f51b819163f5b61a52246c579fccbed9478485784fbb895474d81e"},
+    {file = "pyats.topology-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2bb3cead2a77d48c753267b620cf82e117d61e1f2f98c4b759c4755554f121bb"},
+    {file = "pyats.topology-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:c21a2fe23217c024e70087d62531216335762dc253d83399334e7449bbac4b02"},
+    {file = "pyats.topology-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:cd4677b66197b73905acaa590e13cf422f00bc16de0c2f4cb5d4e93103b0485a"},
+    {file = "pyats.topology-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d1398aead0542c8180dc2a3fbb8bc9ef00948893737c5e160755a3f403985272"},
+    {file = "pyats.topology-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:4eee506769de1981c3904d63fd75657eee440eb66419c03c5f04d03367750789"},
+    {file = "pyats.topology-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:596c689bfe82a7100a3dee87fbda9842861ed29ab39bc3cff8331cd556174ede"},
 ]
 
 [package.dependencies]
-"pyats.connections" = ">=24.2.0,<24.3.0"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.utils" = ">=24.2.0,<24.3.0"
+"pyats.connections" = ">=24.5.0,<24.6.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.utils" = ">=24.5.0,<24.6.0"
 pyyaml = "*"
 yamllint = "*"
 
@@ -1757,34 +1744,33 @@ dev = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats-utils"
-version = "24.2"
+version = "24.5"
 description = "pyATS Utils: Utilities Module"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyats.utils-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:a7b2ee17dc1df2220f1a1f574953091d9e89cd2f83317707dcdcdb112029189d"},
-    {file = "pyats.utils-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:0df7616cbb145ca6d4f3afb0cca2b8b921b764362d97485e25f8dbd5abbda1d9"},
-    {file = "pyats.utils-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:4fc85bc3be8e71154c9cdb5b34e0b6cc33a9522a3508bbf5df6d947271a1b7a4"},
-    {file = "pyats.utils-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:120e5d10d318888b00bca9b9e090eca54c924c36a597fd037a8ba916d463865e"},
-    {file = "pyats.utils-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:a22b99c97f8e840fbad98f0cee4362983e949371f492d051dfb065b791cb1be1"},
-    {file = "pyats.utils-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:af4ee541cf753a45cad0258f573fd25e21ad291555e3c16661b630ef38fdadc2"},
-    {file = "pyats.utils-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ced6fa3c751cf572aaab86d421be28f952a8b84352b78c9e366a23d1047044c9"},
-    {file = "pyats.utils-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:4b72be42ca8093af0931aaab0d13d29aeab351fb72a9779a6cc64dd681d453ae"},
-    {file = "pyats.utils-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:704b3034301c5a7c9c3676129a62848cf05f17d799469f40a86099c7b8df6c08"},
-    {file = "pyats.utils-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:bde4a920041df3b312f299d34fb317272aacc8a64f9bcd5b4ea7b93ac0a84210"},
-    {file = "pyats.utils-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:be6dee1d8217e03dd63f34c4676f6040516bc4da7e5b3a0c249b806d7dc06dc8"},
-    {file = "pyats.utils-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:2b3d0a1d5a674955959a6a2305aa10a163bb0e2204ce03aae035fbc6c93af6a7"},
-    {file = "pyats.utils-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:ddad6cdf0a13699ccdaaa7cd299978cff514ddb8c99b1d52f8490c6fc2b4f2d6"},
-    {file = "pyats.utils-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:64cea392feff487dd77d87be666c2825e26e3f653b7d7d5bd907b6e2357680d3"},
-    {file = "pyats.utils-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:06d808e36ed2319101243cb5de3ff9766c08beddc683524140fc2a471d61d5bb"},
-    {file = "pyats.utils-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:8ee3cd751816226b7f6cc672df10d064ee1b603e4c4595abe1c9b2d27dc6ec90"},
+    {file = "pyats.utils-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:01d601bf9157b889b572427c7ba5adf4d22a029b0126a2c1c30600754f5e201b"},
+    {file = "pyats.utils-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:fec88ca74d5530afdab9b0b5e22819b09a1c9bc6e3f65cb1c0711ccab9ab1761"},
+    {file = "pyats.utils-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:e0844cb4af0c70fe1fff85d0a9f842a916ae004b72bdccd036584d4cd46a9274"},
+    {file = "pyats.utils-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:4346d03aff5a9aa45719ace1e00ebfe363e3446ae151f2e1ffdf1b4886488ee7"},
+    {file = "pyats.utils-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:df326ccb00813cb1bf5581e1195d2d2b284a27937bd0628fcfb55c2cd389a5f1"},
+    {file = "pyats.utils-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:b18718fbdbb9b1f16042121620545f127e7c468c17523bd3ba25e2bf70743c84"},
+    {file = "pyats.utils-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3c42ce340f174f8cfedf35fd44487609e88b89aa237456d51922907574a97525"},
+    {file = "pyats.utils-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:34b336cfa0d0d075cc57152ce870318d95d4a969fc527405098de3a98ce9f462"},
+    {file = "pyats.utils-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:7b79b76b507d32aa06301ee2e85718373600c0dd3fa10d5ccacc1421e1578670"},
+    {file = "pyats.utils-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:ba92dc28ad1a6b2401e624b7150685b2cb241fc9a6734e8182797ebd39ee0417"},
+    {file = "pyats.utils-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6baf2ddd9d6e1dde0f4284003447e4c5fa342b14756611b8d4f9b3ec8003eedb"},
+    {file = "pyats.utils-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:6a92d28587f5a30c94aebc97754ae066874757cdeea1b5dcf463534311ea9904"},
+    {file = "pyats.utils-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:95db5aa13dc0bf3b3ade70122d7882c9a1765b0bedcba28631263b33dd982408"},
+    {file = "pyats.utils-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:4b8f2a0c7f3d500d7bf53f3bf1d88eb2eba880047e4503c29ff5a480634c3fd9"},
+    {file = "pyats.utils-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f9a605cad3b5082b32fbd84e0b9dd545c041383e4aa93fb27ef9ac9afbe8dd67"},
 ]
 
 [package.dependencies]
 cryptography = "*"
 distro = "*"
-"pyats.datastructures" = ">=24.2.0,<24.3.0"
-"pyats.topology" = ">=24.2.0,<24.3.0"
+"pyats.datastructures" = ">=24.5.0,<24.6.0"
+"pyats.topology" = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "requests-mock", "sphinx-rtd-theme"]
@@ -2271,33 +2257,32 @@ files = [
 
 [[package]]
 name = "unicon"
-version = "24.2"
+version = "24.5"
 description = "Unicon Connection Library"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "unicon-24.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:dfa07f7a646d673226238fdf1217466705cf782de93a15fc08c36dbd87cd5174"},
-    {file = "unicon-24.2-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:7992751b41ef034f5e0e20f3ee26991350ec0f9224e80a960c4d077b8f2f37f4"},
-    {file = "unicon-24.2-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:285ab8e5b716b779ea0f5947450a8e1704978736f63164fb76e9573a18c39006"},
-    {file = "unicon-24.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:2e0fdf7ed125be3a29edbafbdcf718bf5fff67d0da9b05bdd88170ff6d1b620d"},
-    {file = "unicon-24.2-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:e19455015f5acafb1fa4d488a3c408239acf4be79bbc4f9fc34707bbe3b6c41d"},
-    {file = "unicon-24.2-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:ed99aa6908e5aae80446262b7b97d0923fe8e47c402c9657b5cedd5275920749"},
-    {file = "unicon-24.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ab5a505baacdd7d37160f202c198e29821c38da7b2e1d56b1e5571aed9e6c8e0"},
-    {file = "unicon-24.2-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:b3e793f1582654dd843cceccb5f895362c7e1f96c6d5c1b5ce3486ce352f8e2d"},
-    {file = "unicon-24.2-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:d880e1004091764e3d5a42984b43f503ca54e27d7cbcad819849a14fd046e781"},
-    {file = "unicon-24.2-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:17c150b9c490a3f20f24e52e538c5591d4258fbb95483e6d8ba9b4de4b84c362"},
-    {file = "unicon-24.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:04a25a5d199f67f11cc241bdccdb0bbd2be52919ea80df95222fb29b0887a325"},
-    {file = "unicon-24.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:decd7998c1ec4ea70dad079c6232032f2e5550441f4f7fd3d3ba9a6073dc7576"},
-    {file = "unicon-24.2-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:36054840061046e0dc9c982b913ec310f4dfb957686b0bba419469e30a57d0b1"},
-    {file = "unicon-24.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:2d1db3825c97deb25fe0fd7515e4baf88c42dfe6fa2792c4253402b7a4f91377"},
-    {file = "unicon-24.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:d199e55a6d8173b0a614dbf66894533fea49025b91b47676e69b369b722f5892"},
-    {file = "unicon-24.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:624d8b107081612281606d3f60bd1587d156f1dabe7c5a2e1359435d57732b35"},
+    {file = "unicon-24.5-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:7b722853e88e2833d242f653c4853034c97587286e56f27bb24b4d8e17d6e21a"},
+    {file = "unicon-24.5-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:d10e048ed34163104e84c4365ce32fc05887b96b6d9bcb44f543bb3cdb4f7882"},
+    {file = "unicon-24.5-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:9fe8fcf4f8888dfa7d2460fb54ed4cf08c0faab8b57ce96f00f38337faf8f23a"},
+    {file = "unicon-24.5-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:d081e997827a192d470f96a88fc6cbaed8d81736d9067ac8139b2cfd898e9d50"},
+    {file = "unicon-24.5-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:bdf8a9366a0f2e888dcd2caad03ff86d9e1a7d00d3c8f376e2690fbd6fba9096"},
+    {file = "unicon-24.5-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:b9d4b0c92c201755844bc09522fd2c6898dd4818f5f2677610855cd313ef5ea6"},
+    {file = "unicon-24.5-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:6af745e2f2e0fc1e3b2ba839fb12a791f14ad883bf9a951b3061aada883b509c"},
+    {file = "unicon-24.5-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:ac72ac50d6d983067cd10b1904790c166243ebf2a48a35ec03f402aa27e49c9f"},
+    {file = "unicon-24.5-cp38-cp38-macosx_11_0_universal2.whl", hash = "sha256:5df2df13c87d8c87fb1edc4cb3cd25f12c0152b6c9194a29c0c3fa2806605299"},
+    {file = "unicon-24.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:f1d072f05fc02707c435f1b12d9e70f74a37b1f5d537dd8b929db5b51120f9bd"},
+    {file = "unicon-24.5-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:db862c848918664c04360238a30ea2848f562a304fd49e5c40575e602595b17f"},
+    {file = "unicon-24.5-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:2be8b4f6fca40814f70a5cf339362202b8da1acc5dc21941471322253488d2f2"},
+    {file = "unicon-24.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c1025e4f2666eb9cb37282bdd965ad455b27f61599d18b91e9f229c72e3d3318"},
+    {file = "unicon-24.5-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:e490f00805ee47072898d6283f106075f757aff39163247ca9db9927797ec35c"},
+    {file = "unicon-24.5-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c802d9dcbb734d6310223f7c631d40fb5711317dba5d91b68ad31c618a2fd058"},
 ]
 
 [package.dependencies]
 dill = "*"
 pyyaml = "*"
-"unicon.plugins" = ">=24.2.0,<24.3.0"
+"unicon.plugins" = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "cisco-distutils", "coverage", "restview", "sphinx-rtd-theme", "sphinxcontrib-mockautodoc", "sphinxcontrib-napoleon"]
@@ -2306,18 +2291,18 @@ robot = ["robotframework"]
 
 [[package]]
 name = "unicon-plugins"
-version = "24.2"
+version = "24.5"
 description = "Unicon Connection Library Plugins"
 optional = false
 python-versions = "*"
 files = [
-    {file = "unicon.plugins-24.2-py3-none-any.whl", hash = "sha256:66d4cc4da01e7db66aa1016c98b0ed71077ef17f87e12f768d3f6b3b27a38947"},
+    {file = "unicon.plugins-24.5-py3-none-any.whl", hash = "sha256:ad54588b16707bfdb74c919850f9d652b0790c8a60583e0c92400fff5aab3c4d"},
 ]
 
 [package.dependencies]
 PrettyTable = "*"
 pyyaml = "*"
-unicon = ">=24.2.0,<24.3.0"
+unicon = ">=24.5.0,<24.6.0"
 
 [package.extras]
 dev = ["Sphinx", "coverage", "pip", "restview", "setuptools", "sphinx-rtd-theme", "sphinxcontrib-mockautodoc", "sphinxcontrib-napoleon", "wheel"]
@@ -2585,4 +2570,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "5f776fe0d414dde88250d1a3db8f9c6e17f04b7c33a6efb63b777580d8a7667c"
+content-hash = "e66dd902563111b0029fe897e81a6fe6ed0cb50aac25ee14703f1afd637e2098"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalyst-sdwan-lab"
-version = "2.0.11"
+version = "2.0.12"
 description = "Catalyst SD-WAN Lab Deployment Tool - Automation Tool for managing Cisco Catalyst SD-WAN labs inside Cisco Modeling Labs"
 license = "BSD-3-Clause"
 authors = ["Tomasz Zarski <tzarski@cisco.com>"]
@@ -17,7 +17,7 @@ python = "^3.9"
 virl2-client = "^2.6.0"
 requests = "^2.28.1"
 pyopenssl = "^24.0.0"
-pyats = ">=23.1,<=24.2"
+pyats = "^24.5"
 passlib = "^1.7.4"
 jinja2 = "3.1.4"
 cisco-sdwan = "^1.23"


### PR DESCRIPTION
- Added CML PATty support
- Bump pyats from 24.2 to 24.5
- In delete task, print lab name when asking user to confirm if lab should be deleted
- In add task, added check to avoid deploying labs with duplicate names (although CML allows labs with duplicate names, this creates confusion for other tasks where lab name is used)
