### PR TITLE
fix(cli): fix setup/delete/backup/restore

### DIFF
--- a/catalyst_sdwan_lab/cli.py
+++ b/catalyst_sdwan_lab/cli.py
@@ -89,8 +89,6 @@ def cli(
         return
     if "-h" in sys.argv or "--help" in sys.argv:
         return
-    if sys.argv[-1] == ctx.invoked_subcommand:
-        return
 
     ctx.ensure_object(dict)
     loglevel = max(logging.DEBUG, logging.WARNING - 10 * verbose)
@@ -121,7 +119,6 @@ def cli(
 @cli.command(
     name="setup",
     short_help="Setup on-prem CML to use Catalyst SD-WAN Lab automation.",
-    no_args_is_help=True,
 )
 @click.option(
     "--list",
@@ -345,7 +342,6 @@ def cli_add(
 @cli.command(
     name="backup",
     short_help="Backup running Catalyst SD-WAN lab pod.",
-    no_args_is_help=True,
 )
 @manager_options
 @click.option(
@@ -389,7 +385,6 @@ def cli_backup(
 @cli.command(
     name="restore",
     short_help="Restore Catalyst SD-WAN POD from backup.",
-    no_args_is_help=True,
 )
 @manager_options
 @gateway_mask_options
@@ -467,7 +462,6 @@ def cli_restore(
 @cli.command(
     name="delete",
     short_help="Delete the CML lab and all the lab data.",
-    no_args_is_help=True,
 )
 @click.option(
     "--lab",


### PR DESCRIPTION
Remove `no_args_is_help` parameters from setup/delete/backup/restore commands as they can be called with no args.

fix #67 

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
