### PR TITLE
refactor: move CML checks/client creation to task subcommands

### DIFF
--- a/catalyst_sdwan_lab/__main__.py
+++ b/catalyst_sdwan_lab/__main__.py
@@ -15,8 +15,9 @@ This module implements the command line top-level parser and task dispatcher
 from catalyst_sdwan_lab.cli import cli
 
 
-def main() -> None:
+def main() -> int:
     cli()
+    return 0
 
 
 if __name__ == "__main__":

--- a/catalyst_sdwan_lab/tasks/backup.py
+++ b/catalyst_sdwan_lab/tasks/backup.py
@@ -19,7 +19,7 @@ from cisco_sdwan.tasks.implementation import BackupArgs, TaskBackup
 from jinja2 import Environment, FileSystemLoader
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import LiteralScalarString
-from virl2_client import ClientLibrary
+from virl2_client import ClientConfig
 from virl2_client.models.cl_pyats import ClPyats
 
 from .utils import (
@@ -27,6 +27,7 @@ from .utils import (
     load_certificate_details,
     setup_logging,
     track_progress,
+    verify_cml_version,
 )
 
 
@@ -138,9 +139,7 @@ def check_pyats_device_connectivity(
 
 
 def main(
-    cml: ClientLibrary,
-    cml_user: str,
-    cml_password: str,
+    cml_config: ClientConfig,
     manager_ip: str,
     manager_port: int,
     manager_user: str,
@@ -154,6 +153,12 @@ def main(
 
     # Setup logging
     log = setup_logging(loglevel)
+
+    # create cml instance and check version
+    cml = cml_config.make_client()
+    verify_cml_version(cml)
+    cml_user = cml_config.username
+    cml_password = cml_config.password
 
     track_progress(log, "Preparing for backup...")
 

--- a/catalyst_sdwan_lab/tasks/delete.py
+++ b/catalyst_sdwan_lab/tasks/delete.py
@@ -6,18 +6,22 @@
 
 from typing import Union
 
-from virl2_client import ClientLibrary
+from virl2_client import ClientConfig
 
-from .utils import setup_logging, track_progress
+from .utils import setup_logging, track_progress, verify_cml_version
 
 
 def main(
-    cml: ClientLibrary, lab_name: str, force: bool, loglevel: Union[str, int]
+    cml_config: ClientConfig, lab_name: str, force: bool, loglevel: Union[str, int]
 ) -> None:
 
     # Setup logging
     log = setup_logging(loglevel)
     track_progress(log, "Preparing delete task...")
+
+    # create cml instance and check version
+    cml = cml_config.make_client()
+    verify_cml_version(cml)
 
     # Find the lab
     lab = cml.find_labs_by_title(lab_name)

--- a/catalyst_sdwan_lab/tasks/deploy.py
+++ b/catalyst_sdwan_lab/tasks/deploy.py
@@ -12,7 +12,7 @@ from typing import Union
 from catalystwan.endpoints.configuration_device_inventory import SerialFilePayload
 from jinja2 import Environment, FileSystemLoader
 from passlib.hash import sha512_crypt
-from virl2_client import ClientLibrary
+from virl2_client import ClientConfig
 
 from .utils import (
     CML_DEPLOY_LAB_DEFINITION_DIR,
@@ -30,13 +30,13 @@ from .utils import (
     restore_manager_configuration,
     setup_logging,
     track_progress,
+    verify_cml_version,
     wait_for_manager_session,
 )
 
 
 def main(
-    cml: ClientLibrary,
-    cml_ip: str,
+    cml_config: ClientConfig,
     manager_ip: str,
     manager_port: int,
     manager_mask: str,
@@ -56,6 +56,10 @@ def main(
 
     # Setup logging
     log = setup_logging(loglevel)
+
+    # create cml instance and check version
+    cml = cml_config.make_client()
+    verify_cml_version(cml)
 
     # Verify if requested software version is defined in CML
     track_progress(log, "Preparing the lab...")
@@ -212,7 +216,7 @@ def main(
     print(
         f"#############################################\n"
         f"Lab is deployed.\n"
-        f"CML URL: https://{cml_ip}\n"
+        f"CML URL: https://{cml_config.url}\n"
         f"SD-WAN Manager URL: https://{manager_ip}:{manager_port}\n"
         f"Use the username/password set with the script for CML and SD-WAN Manager login.\n"
         f"All other nodes use default username/password.\n"

--- a/catalyst_sdwan_lab/tasks/restore.py
+++ b/catalyst_sdwan_lab/tasks/restore.py
@@ -17,7 +17,7 @@ from catalystwan.endpoints.configuration_device_inventory import SerialFilePaylo
 from cisco_sdwan.base.rest_api import Rest
 from passlib.hash import sha512_crypt
 from ruamel.yaml import YAML
-from virl2_client import ClientLibrary
+from virl2_client import ClientConfig
 
 from . import delete
 from .utils import (
@@ -30,14 +30,14 @@ from .utils import (
     restore_manager_configuration,
     setup_logging,
     track_progress,
+    verify_cml_version,
     wait_for_manager_session,
     wait_for_wan_edge_onboaring,
 )
 
 
 def main(
-    cml: ClientLibrary,
-    cml_ip: str,
+    cml_config: ClientConfig,
     manager_ip: str,
     manager_port: int,
     manager_mask: str,
@@ -56,6 +56,10 @@ def main(
 
     # Setup logging
     log = setup_logging(loglevel)
+
+    # create cml instance and check version
+    cml = cml_config.make_client()
+    verify_cml_version(cml)
 
     # Setup YAML
     yaml = YAML(typ="rt")
@@ -427,7 +431,7 @@ def main(
     print(
         f"#############################################\n"
         f"Lab is restored.\n"
-        f"CML URL: https://{cml_ip}\n"
+        f"CML URL: https://{cml_config.url}\n"
         f"SD-WAN Manager URL: https://{manager_ip}:8443\n"
         f"Use the username/password set with the script for CML and SD-WAN Manager login.\n"
         f"All other nodes use default username/password.\n"

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -13,13 +13,14 @@ from typing import List, Union
 
 from httpx import HTTPStatusError
 from ruamel.yaml import YAML
-from virl2_client import ClientLibrary
+from virl2_client import ClientConfig, ClientLibrary
 
 from .utils import (
     CML_NODES_DEFINITION_DIR,
     SOFTWARE_IMAGES_DIR,
     setup_logging,
     track_progress,
+    verify_cml_version,
 )
 
 
@@ -49,9 +50,13 @@ def upload_image_and_create_definition(
         cml.definitions.upload_image_definition(body=json.dumps(image_def))
 
 
-def main(cml: ClientLibrary, loglevel: Union[int, str], list: bool) -> None:
+def main(cml_config: ClientConfig, loglevel: Union[int, str], list: bool) -> None:
     # Setup logging
     log = setup_logging(loglevel)
+
+    # create cml instance and check version
+    cml = cml_config.make_client()
+    verify_cml_version(cml)
 
     # Setup YAML
     yaml = YAML(typ="rt")

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -187,6 +187,13 @@ def create_cert(ca_cert_str: str, ca_key_str: str, csr_str: str) -> str:
     return crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode()
 
 
+def verify_cml_version(cml: ClientLibrary) -> None:
+    if cml.VERSION.major == 2 and cml.VERSION.minor >= 6:
+        pass
+    else:
+        exit("Upgrade CML to 2.6 or later to use the tool.")
+
+
 def get_cml_sdwan_image_definition(
     cml: ClientLibrary, node_definition: str, software_version: str
 ) -> str:


### PR DESCRIPTION
## Description

Move CML version verification and client creation to task subcommands for better separation of concerns. Update task functions to use ClientConfig instead of ClientLibrary for improved encapsulation of connection details.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
