### PR TITLE
Image definition cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - In setup task, add option to delete already defined software images
 - Fix issue where add task might fail for SD-WAN Manager 20.18 and higher
+- In setup task, change behaviour when --list is specified, print software version and exit
 
 # Catalyst SD-WAN Lab 2.0.15 [Feb 25, 2025]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# Catalyst SD-WAN Lab 2.0.15 [unreleased]
+# Catalyst SD-WAN Lab 2.0.16 [unreleased]
 
 - In setup task, add option to delete already defined software images
+- Fix issue where add task might fail for SD-WAN Manager 20.18 and higher
 
 # Catalyst SD-WAN Lab 2.0.15 [Feb 25, 2025]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Catalyst SD-WAN Lab 2.0.15 [unreleased]
+
+- In setup task, add option to delete already defined software images
+
 # Catalyst SD-WAN Lab 2.0.15 [Feb 25, 2025]
 
 - Fixed a problem where the backup task might fail with a "KeyError: 'label'"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - In setup task, add option to delete already defined software images
 - Fix issue where add task might fail for SD-WAN Manager 20.18 and higher
 - In setup task, change behaviour when --list is specified, print software version and exit
+- Update validator cloud-init to support 20.18 release
 
 # Catalyst SD-WAN Lab 2.0.15 [Feb 25, 2025]
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,7 @@ This task can also delete existing image definitions to clean up old SD-WAN rele
       │ --delete  -d  <software_versions>  Delete all image definitions for the specified software           │
       │                                    version(s). To specify multiple versions, separate them with a    │
       │                                    comma.                                                            │
-      │ --list    -l                       After running setup task, list the available SD-WAN software per  │
-      │                                    node type.                                                        │
+      │ --list    -l                       List the available SD-WAN software per node type and exit.        │
       │ --help    -h                       Show this message and exit.                                       │
       ╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Task-specific parameters are provided after the task argument.
       │ delete                  Delete the CML lab and all the lab data.                                                                                                                           │
       │ deploy                  Deploy a new Catalyst SD-WAN lab pod.                                                                                                                              │
       │ restore                 Restore Catalyst SD-WAN POD from backup.                                                                                                                           │
-      │ setup                   Setup on-prem CML to use Catalyst SD-WAN Lab automation.                                                                                                           │
+      │ setup                   Setup CML to use Catalyst SD-WAN Lab automation.                                                                                                           │
       │ sign                    Sign CSR using the SD-WAN Lab Deployment Tool Root CA.                                                                                                             │
       ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
@@ -170,16 +170,20 @@ This task makes sure your CML is ready to run Catalyst SD-WAN labs. The task wil
 
 On each CML server that you want to use, you should run a setup task at least once to create required node and image definitions. You can rerun the setup task each time you want to add a new Catalyst SD-WAN software image to your CML server.
 
-This task have one task-specific argument that allows you to migrate the node and image definitions to new format if you've used SD-WAN Lab 1.x in the past.
+This task can also delete existing image definitions to clean up old SD-WAN releases from CML server.
 
       sdwan-lab setup -h
 
        Usage: sdwan-lab setup [OPTIONS]
 
-      ╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-      │ --list  -l    After running setup task, list the available SD-WAN software per node type.                                                                                                  │
-      │ --help  -h    Show this message and exit.                                                                                                                                                  │
-      ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+      ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────╮
+      │ --delete  -d  <software_versions>  Delete all image definitions for the specified software           │
+      │                                    version(s). To specify multiple versions, separate them with a    │
+      │                                    comma.                                                            │
+      │ --list    -l                       After running setup task, list the available SD-WAN software per  │
+      │                                    node type.                                                        │
+      │ --help    -h                       Show this message and exit.                                       │
+      ╰──────────────────────────────────────────────────────────────────────────────────────────────────────╯
 
 ### Deploy Task
 

--- a/catalyst_sdwan_lab/cli.py
+++ b/catalyst_sdwan_lab/cli.py
@@ -139,7 +139,7 @@ def cli(
     "-l",
     "list_",
     is_flag=True,
-    help="After running setup task, list the available SD-WAN software per node type.",
+    help="List the available SD-WAN software per node type and exit.",
 )
 @click.pass_context
 def cli_setup(ctx: click.Context, list_: bool, delete: str = None) -> None:

--- a/catalyst_sdwan_lab/cli.py
+++ b/catalyst_sdwan_lab/cli.py
@@ -125,7 +125,14 @@ def cli(
 
 @cli.command(
     name="setup",
-    short_help="Setup on-prem CML to use Catalyst SD-WAN Lab automation.",
+    short_help="Setup CML to use Catalyst SD-WAN Lab automation.",
+)
+@click.option(
+    "--delete",
+    "-d",
+    metavar="<software_versions>",
+    help="Delete all image definitions for the specified software version(s). "
+    "To specify multiple versions, separate them with a comma.",
 )
 @click.option(
     "--list",
@@ -135,8 +142,13 @@ def cli(
     help="After running setup task, list the available SD-WAN software per node type.",
 )
 @click.pass_context
-def cli_setup(ctx: click.Context, list_: bool) -> None:
-    setup.main(ctx.obj["CML_CONFIG"], ctx.obj["LOGLEVEL"], list_)
+def cli_setup(ctx: click.Context, list_: bool, delete: str = None) -> None:
+    software_versions_to_delete = None
+    if delete:
+        software_versions_to_delete = delete.split(",")
+    setup.main(
+        ctx.obj["CML_CONFIG"], ctx.obj["LOGLEVEL"], list_, software_versions_to_delete
+    )
 
 
 def manager_options(f: Callable[..., Any]) -> Callable[..., Any]:

--- a/catalyst_sdwan_lab/cli.py
+++ b/catalyst_sdwan_lab/cli.py
@@ -142,8 +142,8 @@ def cli(
     help="List the available SD-WAN software per node type and exit.",
 )
 @click.pass_context
-def cli_setup(ctx: click.Context, list_: bool, delete: str = None) -> None:
-    software_versions_to_delete = None
+def cli_setup(ctx: click.Context, list_: bool, delete: str = "") -> None:
+    software_versions_to_delete = []
     if delete:
         software_versions_to_delete = delete.split(",")
     setup.main(

--- a/catalyst_sdwan_lab/data/cml_lab_definition/backup/validator-cloud-init.j2
+++ b/catalyst_sdwan_lab/data/cml_lab_definition/backup/validator-cloud-init.j2
@@ -1,7 +1,5 @@
 #cloud-config
 write_files:
-- path: /etc/default/personality
-  content: "vedge\n"
 - path: /etc/default/inited
   content: "1\n"
 - path: /usr/share/viptela/symantec-root-ca.crt

--- a/catalyst_sdwan_lab/data/cml_lab_definition/deploy/validator-cloud-init.j2
+++ b/catalyst_sdwan_lab/data/cml_lab_definition/deploy/validator-cloud-init.j2
@@ -1,7 +1,5 @@
 #cloud-config
 write_files:
-- path: /etc/default/personality
-  content: "vedge\n"
 - path: /etc/default/inited
   content: "1\n"
 - path: /usr/share/viptela/symantec-root-ca.crt

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -14,6 +14,7 @@ from typing import List, Union
 from httpx import HTTPStatusError
 from ruamel.yaml import YAML
 from virl2_client import ClientConfig, ClientLibrary
+from virl2_client.exceptions import APIError
 
 from .utils import (
     CML_NODES_DEFINITION_DIR,
@@ -50,162 +51,218 @@ def upload_image_and_create_definition(
         cml.definitions.upload_image_definition(body=json.dumps(image_def))
 
 
-def main(cml_config: ClientConfig, loglevel: Union[int, str], list: bool) -> None:
+def main(
+    cml_config: ClientConfig,
+    loglevel: Union[int, str],
+    list: bool,
+    software_versions_to_delete: List[str],
+) -> None:
     # Setup logging
     log = setup_logging(loglevel)
+
+    warnings = []
 
     # create cml instance and check version
     cml = cml_config.make_client()
     verify_cml_version(cml)
 
-    # Setup YAML
-    yaml = YAML(typ="rt")
-
-    track_progress(log, "Verifying Node Definitions...")
-    # Collect node definitions from CML
-    node_definitions = cml.definitions.node_definitions()
-    for filename in os.listdir(CML_NODES_DEFINITION_DIR):
-        if filename.endswith(".yaml"):
-            # For every YAML file in the node definition folder, we need to do below steps
-            # Load node definition from the file
-            with open(join(CML_NODES_DEFINITION_DIR, filename), "r") as f:
-                new_node_definition = yaml.load(f.read())
-
-            # Check if the node is already defined in CML
-            # This returns node definition or None if node with this id doesn't exist
-            current_node_definition = next(
-                (
-                    node
-                    for node in node_definitions
-                    if node["id"] == new_node_definition["id"]
-                ),
-                None,
-            )
-            if current_node_definition:
-                # If node already exists, we need to check if it requires update
-                if new_node_definition == current_node_definition:
-                    # If dicts are same then no update is required
-                    log.info(
-                        f'[KEEP] Node {current_node_definition["id"]} is already defined and up to date.'
-                    )
-                else:
-                    # If dicts are not the same, then we need to update the node definition
-                    # Before update, check if node definition is read only
-                    if current_node_definition["general"]["read_only"]:
-                        # Remove read-only flag
-                        cml.definitions.set_node_definition_read_only(
-                            current_node_definition["id"], False
-                        )
-
-                    log.info(
-                        f'[UPDATE] Updating node {new_node_definition["id"]} with '
-                        f'{new_node_definition["sim"]["linux_native"]["cpus"]} CPUs and '
-                        f'{new_node_definition["sim"]["linux_native"]["ram"]} MB RAM.'
+    if software_versions_to_delete is not None:
+        track_progress(log, "Checking software versions to delete...")
+        node_types = [
+            "cat-sdwan-manager",
+            "cat-sdwan-controller",
+            "cat-sdwan-validator",
+            "cat-sdwan-edge",
+        ]
+        # Create a dictionary that maps image definition IDs to disk image filenames
+        # for example: {cat-sdwan-manager-20.12.3: viptela-vmanage-20.12.3-genericx86-64.qcow2}
+        existing_image_definitions_ids_to_filename = {
+            image["id"]: image["disk_image"]
+            for image in cml.definitions.image_definitions()
+        }
+        image_files_to_delete = []
+        for software_version in software_versions_to_delete:
+            for node_type in node_types:
+                if (
+                    f"{node_type}-{software_version}"
+                    in existing_image_definitions_ids_to_filename.keys()
+                ):
+                    track_progress(
+                        log,
+                        f"Deleting image definition {node_type}-{software_version}...",
                     )
                     try:
-                        # For virl2_client lower than 2.7.0
-                        cml.session.put("node_definitions/", json=new_node_definition)
-                    except AttributeError:
-                        # For virl2_client 2.7.0 and higher
-                        cml.definitions.upload_node_definition(
-                            new_node_definition, True
+                        cml.definitions.remove_image_definition(
+                            f"{node_type}-{software_version}"
                         )
+                        image_files_to_delete.append(
+                            existing_image_definitions_ids_to_filename[
+                                f"{node_type}-{software_version}"
+                            ]
+                        )
+                    except APIError as e:
+                        log.warning(
+                            f"Cannot delete image definition {node_type}-{software_version}: {e}"
+                        )
+                        warnings.append(
+                            f"Cannot delete image definition {node_type}-{software_version}: {e}"
+                        )
+        for image_file in image_files_to_delete:
+            track_progress(log, f"Deleting image file {image_file}...")
+            cml.definitions.remove_dropfolder_image(image_file)
+    else:
+        # Setup YAML
+        yaml = YAML(typ="rt")
+
+        track_progress(log, "Verifying Node Definitions...")
+        # Collect node definitions from CML
+        node_definitions = cml.definitions.node_definitions()
+        for filename in os.listdir(CML_NODES_DEFINITION_DIR):
+            if filename.endswith(".yaml"):
+                # For every YAML file in the node definition folder, we need to do below steps
+                # Load node definition from the file
+                with open(join(CML_NODES_DEFINITION_DIR, filename), "r") as f:
+                    new_node_definition = yaml.load(f.read())
+
+                # Check if the node is already defined in CML
+                # This returns node definition or None if node with this id doesn't exist
+                current_node_definition = next(
+                    (
+                        node
+                        for node in node_definitions
+                        if node["id"] == new_node_definition["id"]
+                    ),
+                    None,
+                )
+                if current_node_definition:
+                    # If node already exists, we need to check if it requires update
+                    if new_node_definition == current_node_definition:
+                        # If dicts are same then no update is required
+                        log.info(
+                            f'[KEEP] Node {current_node_definition["id"]} is already defined and up to date.'
+                        )
+                    else:
+                        # If dicts are not the same, then we need to update the node definition
+                        # Before update, check if node definition is read only
+                        if current_node_definition["general"]["read_only"]:
+                            # Remove read-only flag
+                            cml.definitions.set_node_definition_read_only(
+                                current_node_definition["id"], False
+                            )
+
+                        log.info(
+                            f'[UPDATE] Updating node {new_node_definition["id"]} with '
+                            f'{new_node_definition["sim"]["linux_native"]["cpus"]} CPUs and '
+                            f'{new_node_definition["sim"]["linux_native"]["ram"]} MB RAM.'
+                        )
+                        try:
+                            # For virl2_client lower than 2.7.0
+                            cml.session.put(
+                                "node_definitions/", json=new_node_definition
+                            )
+                        except AttributeError:
+                            # For virl2_client 2.7.0 and higher
+                            cml.definitions.upload_node_definition(
+                                new_node_definition, True
+                            )
+                else:
+                    # If node is not yet created, we need to create it
+                    log.info(f'[CREATE] Creating node {new_node_definition["id"]}...')
+                    cml.definitions.upload_node_definition(
+                        new_node_definition, json=True
+                    )
+
+        # Refresh node definitions
+        node_definitions = cml.definitions.node_definitions()
+        track_progress(log, "Verifying software images...")
+        # Get the list of all image definitions already created in CML.
+        # This is to avoid image duplication during upload.
+        existing_image_definitions = cml.definitions.image_definitions()
+        existing_image_definitions_ids = [
+            image_definition["id"] for image_definition in existing_image_definitions
+        ]
+
+        for image_definition in existing_image_definitions:
+            match = re.match(
+                r"^cat-sdwan-(edge|controller|validator|manager)-([\w\-]+)$",
+                image_definition["id"],
+            )
+            if match:
+                # Migrate image from using - in software version to using .
+                # For example from cat-sdwan-manager-20-13-1 to cat-sdwan-manager-20.13.1
+                # Before update, check if node definition is read only
+                if image_definition["read_only"]:
+                    # Remove read-only flag
+                    cml.definitions.set_image_definition_read_only(
+                        image_definition["id"], False
+                    )
+                try:
+                    cml.definitions.remove_image_definition(image_definition["id"])
+                    # Set new ID and disk folder
+                    image_definition["id"] = (
+                        f"cat-sdwan-{match.group(1)}-{match.group(2).replace('-', '.')}"
+                    )
+                    image_definition["disk_subfolder"] = image_definition["id"]
+                    cml.definitions.upload_image_definition(image_definition)
+                except HTTPStatusError:
+                    warnings.append(
+                        f"Cannot setup image {image_definition['id']} as it's currently in use by a lab."
+                    )
+
+        log.info(f"Looking for new software images in {os.getcwd()}...")
+        software_type_to_node_type_mapping = {
+            "edge": "cat-sdwan-validator",
+            "bond": "cat-sdwan-validator",
+            "smart": "cat-sdwan-controller",
+            "vmanage": "cat-sdwan-manager",
+        }
+
+        # Check for any software that is present in software_images folder.
+        for filename in os.listdir(SOFTWARE_IMAGES_DIR):
+            if software_parser := re.match(r"viptela-(\w+)-([\d.]+)-", filename):
+                # For viptela software we need to extract image type (vmanage, smart, edge) and version.
+                node_type = software_type_to_node_type_mapping[software_parser.group(1)]
+                node_label = next(
+                    node["ui"]["label"]
+                    for node in node_definitions
+                    if node["id"] == node_type
+                )
+                software_version = software_parser.group(2)
+                upload_image_and_create_definition(
+                    log,
+                    cml,
+                    existing_image_definitions_ids,
+                    node_type,
+                    software_version,
+                    node_label,
+                    SOFTWARE_IMAGES_DIR,
+                    filename,
+                )
+
+            elif software_parser := re.match(
+                r"c8000v-universalk9_\d+G_serial\.([.\w]+)\.qcow2$", filename
+            ):
+                # For C8000v we need to make sure it is a serial image.
+                node_type = "cat-sdwan-edge"
+                node_label = next(
+                    node["ui"]["label"]
+                    for node in node_definitions
+                    if node["id"] == node_type
+                )
+                software_version = software_parser.group(1)
+                upload_image_and_create_definition(
+                    log,
+                    cml,
+                    existing_image_definitions_ids,
+                    node_type,
+                    software_version,
+                    node_label,
+                    SOFTWARE_IMAGES_DIR,
+                    filename,
+                )
+
             else:
-                # If node is not yet created, we need to create it
-                log.info(f'[CREATE] Creating node {new_node_definition["id"]}...')
-                cml.definitions.upload_node_definition(new_node_definition, json=True)
-
-    # Refresh node definitions
-    node_definitions = cml.definitions.node_definitions()
-    track_progress(log, "Verifying software images...")
-    # Get the list of all image definitions already created in CML.
-    # This is to avoid image duplication during upload.
-    existing_image_definitions = cml.definitions.image_definitions()
-    existing_image_definitions_ids = [
-        image_definition["id"] for image_definition in existing_image_definitions
-    ]
-    warnings = []
-    for image_definition in existing_image_definitions:
-        match = re.match(
-            r"^cat-sdwan-(edge|controller|validator|manager)-([\w\-]+)$",
-            image_definition["id"],
-        )
-        if match:
-            # Migrate image from using - in software version to using .
-            # For example from cat-sdwan-manager-20-13-1 to cat-sdwan-manager-20.13.1
-            # Before update, check if node definition is read only
-            if image_definition["read_only"]:
-                # Remove read-only flag
-                cml.definitions.set_image_definition_read_only(
-                    image_definition["id"], False
-                )
-            try:
-                cml.definitions.remove_image_definition(image_definition["id"])
-                # Set new ID and disk folder
-                image_definition["id"] = (
-                    f"cat-sdwan-{match.group(1)}-{match.group(2).replace('-', '.')}"
-                )
-                image_definition["disk_subfolder"] = image_definition["id"]
-                cml.definitions.upload_image_definition(image_definition)
-            except HTTPStatusError:
-                warnings.append(
-                    f"Cannot setup image {image_definition['id']} as it's currently in use by a lab."
-                )
-
-    log.info(f"Looking for new software images in {os.getcwd()}...")
-    software_type_to_node_type_mapping = {
-        "edge": "cat-sdwan-validator",
-        "bond": "cat-sdwan-validator",
-        "smart": "cat-sdwan-controller",
-        "vmanage": "cat-sdwan-manager",
-    }
-
-    # Check for any software that is present in software_images folder.
-    for filename in os.listdir(SOFTWARE_IMAGES_DIR):
-        if software_parser := re.match(r"viptela-(\w+)-([\d.]+)-", filename):
-            # For viptela software we need to extract image type (vmanage, smart, edge) and version.
-            node_type = software_type_to_node_type_mapping[software_parser.group(1)]
-            node_label = next(
-                node["ui"]["label"]
-                for node in node_definitions
-                if node["id"] == node_type
-            )
-            software_version = software_parser.group(2)
-            upload_image_and_create_definition(
-                log,
-                cml,
-                existing_image_definitions_ids,
-                node_type,
-                software_version,
-                node_label,
-                SOFTWARE_IMAGES_DIR,
-                filename,
-            )
-
-        elif software_parser := re.match(
-            r"c8000v-universalk9_\d+G_serial\.([.\w]+)\.qcow2$", filename
-        ):
-            # For C8000v we need to make sure it is a serial image.
-            node_type = "cat-sdwan-edge"
-            node_label = next(
-                node["ui"]["label"]
-                for node in node_definitions
-                if node["id"] == node_type
-            )
-            software_version = software_parser.group(1)
-            upload_image_and_create_definition(
-                log,
-                cml,
-                existing_image_definitions_ids,
-                node_type,
-                software_version,
-                node_label,
-                SOFTWARE_IMAGES_DIR,
-                filename,
-            )
-
-        else:
-            log.debug(f"Skipping file {filename} (not a valid image).")
+                log.debug(f"Skipping file {filename} (not a valid image).")
 
     track_progress(log, "Setup task done\n")
     if warnings:

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -282,6 +282,7 @@ def main(
             else:
                 log.debug(f"Skipping file {filename} (not a valid image).")
 
+    if not list:
         track_progress(log, "Setup task done\n")
         if warnings:
             print("Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings))

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -66,7 +66,25 @@ def main(
     cml = cml_config.make_client()
     verify_cml_version(cml)
 
-    if software_versions_to_delete is not None:
+    if list:
+        print("Available Software Versions:")
+        for node_definition_id in [
+            "cat-sdwan-manager",
+            "cat-sdwan-controller",
+            "cat-sdwan-validator",
+            "cat-sdwan-edge",
+        ]:
+            available_software_versions = []
+            # List available SD-WAN software
+            for (
+                image_definition
+            ) in cml.definitions.image_definitions_for_node_definition(
+                node_definition_id
+            ):
+                available_software_versions.append(image_definition["id"].split("-")[3])
+            print(f"- {node_definition_id}: {available_software_versions}\n")
+
+    elif software_versions_to_delete is not None:
         track_progress(log, "Checking software versions to delete...")
         node_types = [
             "cat-sdwan-manager",
@@ -264,24 +282,6 @@ def main(
             else:
                 log.debug(f"Skipping file {filename} (not a valid image).")
 
-    track_progress(log, "Setup task done\n")
-    if warnings:
-        print("Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings))
-
-    if list:
-        print("Available Software Versions:")
-        for node_definition_id in [
-            "cat-sdwan-manager",
-            "cat-sdwan-controller",
-            "cat-sdwan-validator",
-            "cat-sdwan-edge",
-        ]:
-            available_software_versions = []
-            # List available SD-WAN software
-            for (
-                image_definition
-            ) in cml.definitions.image_definitions_for_node_definition(
-                node_definition_id
-            ):
-                available_software_versions.append(image_definition["id"].split("-")[3])
-            print(f"- {node_definition_id}: {available_software_versions}")
+        track_progress(log, "Setup task done\n")
+        if warnings:
+            print("Warnings:\n" + "\n".join(f"- {warning}" for warning in warnings))

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -84,7 +84,7 @@ def main(
                 available_software_versions.append(image_definition["id"].split("-")[3])
             print(f"- {node_definition_id}: {available_software_versions}\n")
 
-    elif software_versions_to_delete is not None:
+    elif software_versions_to_delete:
         track_progress(log, "Checking software versions to delete...")
         node_types = [
             "cat-sdwan-manager",

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -28,8 +28,8 @@ from catalystwan.endpoints.configuration_settings import (
     CloudX,
     Device,
     Organization,
-    VManageDataStream,
     VEdgeCloud,
+    VManageDataStream,
 )
 from catalystwan.exceptions import ManagerHTTPError, ManagerRequestException
 from catalystwan.session import ManagerSession, create_manager_session

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -29,6 +29,7 @@ from catalystwan.endpoints.configuration_settings import (
     Device,
     Organization,
     VManageDataStream,
+    VEdgeCloud,
 )
 from catalystwan.exceptions import ManagerHTTPError, ManagerRequestException
 from catalystwan.session import ManagerSession, create_manager_session
@@ -147,6 +148,7 @@ def configure_manager_basic_settings(
     else:
         log.info("Org-name is already set")
     manager_config_settings.edit_devices(Device(domain_ip=VALIDATOR_FQDN))
+    manager_config_settings.edit_vedge_cloud(VEdgeCloud(certificateauthority="vmanage"))
     manager_session.post(
         "/dataservice/settings/configuration/certificate",
         json={"certificateSigning": "enterprise"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalyst-sdwan-lab"
-version = "2.0.15"
+version = "2.0.16dev1"
 description = "Catalyst SD-WAN Lab Deployment Tool - Automation Tool for managing Cisco Catalyst SD-WAN labs inside Cisco Modeling Labs"
 license = "BSD-3-Clause"
 authors = ["Tomasz Zarski <tzarski@cisco.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalyst-sdwan-lab"
-version = "2.0.16dev1"
+version = "2.0.16dev3"
 description = "Catalyst SD-WAN Lab Deployment Tool - Automation Tool for managing Cisco Catalyst SD-WAN labs inside Cisco Modeling Labs"
 license = "BSD-3-Clause"
 authors = ["Tomasz Zarski <tzarski@cisco.com>"]


### PR DESCRIPTION
When you CML cluster with this tool has run for sometime, you might start to use many different versions of SD-WAN Manager controllers etc. Cleaning up those on the CML Cluster is very tedious.

Create a "clean-up" task in the same fashion as the setup step, that can cleanup unused definitions from the CML cluster and remove the files from the CML server.

