### PR TITLE
drop support CML 2.6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+# Catalyst SD-WAN Lab 2.1.1 [Jun 18, 2025]
+
+- Print error when user tries to use the SD-WAN Lab Tool 2.1.x or higher against CML 2.6.x
+
 # Catalyst SD-WAN Lab 2.1.0 [Jun 17, 2025]
 
+- Drop support for CML 2.6.x
 - Add support for IPv6 and dual stack overlays
 - Change Gateway node type from c8000v to IOL XE
 - Change transports node type from unmanaged_switch to IOL L2 XE

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -208,10 +208,10 @@ def create_cert(ca_cert_str: str, ca_key_str: str, csr_str: str) -> str:
 
 
 def verify_cml_version(cml: ClientLibrary) -> None:
-    if cml.VERSION.major == 2 and cml.VERSION.minor >= 6:
+    if cml.VERSION.major == 2 and cml.VERSION.minor >= 7:
         pass
     else:
-        exit("Upgrade CML to 2.6 or later to use the tool.")
+        exit("Upgrade CML to 2.7 or later to use the tool.")
 
 
 def get_cml_sdwan_image_definition(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "catalyst-sdwan-lab"
-version = "2.1.0"
+version = "2.1.1"
 description = "Catalyst SD-WAN Lab Deployment Tool - Automation Tool for managing Cisco Catalyst SD-WAN labs inside Cisco Modeling Labs"
 license = "BSD-3-Clause"
 authors = ["Tomasz Zarski <tzarski@cisco.com>"]


### PR DESCRIPTION
Provide error when user tries to used Lab Tool 2.1.x or higher against CML 2.6.x or lower.