### PR TITLE
BugFix110, to provide correct information at the end of restore task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Catalyst SD-WAN Lab 2.1.5 [unreleased]
+
+- In restore task, fix issue where the final output contains port 8443 instead of port used by PATty
+
 # Catalyst SD-WAN Lab 2.1.4 [Sep 10, 2025]
 
 - Fix issue where SD-WAN Manager might not boot in CML 2.8 and 2.9

--- a/catalyst_sdwan_lab/tasks/restore.py
+++ b/catalyst_sdwan_lab/tasks/restore.py
@@ -521,7 +521,7 @@ def main(
         f"#############################################\n"
         f"Lab is restored.\n"
         f"CML URL: https://{cml_config.url}\n"
-        f"SD-WAN Manager URL: https://{manager_ip}:8443\n"
+        f"SD-WAN Manager URL: https://{manager_ip}:{manager_port}\n"
         f"Use the username/password set with the script for CML and SD-WAN Manager login.\n"
         f"All other nodes use default username/password.\n"
         f"#############################################"


### PR DESCRIPTION
## Description

when running a restore task, this fix will show the correct manager port in case is different to 8443

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X ] Existing issues have been referenced (where applicable)
- [ X] I have verified this change is not present in other open pull requests
- [ X] Functionality is documented
- [ X] All code style checks pass
- [X ] New code contribution is covered by automated tests
- [X ] All new and existing tests pass
