### PR TITLE
fix IndexError in setup task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Catalyst SD-WAN Lab 2.1.8 [Mar 5, 2026]
+
+- In setup task, fix issue where --list would fail with `IndexError: list index out of range` when user has invalid image definitions created manually in CML
+
 # Catalyst SD-WAN Lab 2.1.7 [Feb 3, 2026]
 
 - In restore task, add backward compatibility for restoring old backups with legacy disk naming (sdb to vdb conversion for virtio disks)

--- a/catalyst_sdwan_lab/tasks/setup.py
+++ b/catalyst_sdwan_lab/tasks/setup.py
@@ -81,7 +81,9 @@ def main(
             ) in cml.definitions.image_definitions_for_node_definition(
                 node_definition_id
             ):
-                available_software_versions.append(image_definition["id"].split("-")[3])
+                parts = image_definition["id"].split("-")
+                if len(parts) > 3:
+                    available_software_versions.append(parts[3])
             print(f"- {node_definition_id}: {available_software_versions}\n")
 
     elif software_versions_to_delete:
@@ -166,7 +168,7 @@ def main(
                     if new_node_definition == current_node_definition:
                         # If dicts are same then no update is required
                         log.info(
-                            f'[KEEP] Node {current_node_definition["id"]} is already defined and up to date.'
+                            f"[KEEP] Node {current_node_definition['id']} is already defined and up to date."
                         )
                     else:
                         # If dicts are not the same, then we need to update the node definition
@@ -178,9 +180,9 @@ def main(
                             )
 
                         log.info(
-                            f'[UPDATE] Updating node {new_node_definition["id"]} with '
-                            f'{new_node_definition["sim"]["linux_native"]["cpus"]} CPUs and '
-                            f'{new_node_definition["sim"]["linux_native"]["ram"]} MB RAM.'
+                            f"[UPDATE] Updating node {new_node_definition['id']} with "
+                            f"{new_node_definition['sim']['linux_native']['cpus']} CPUs and "
+                            f"{new_node_definition['sim']['linux_native']['ram']} MB RAM."
                         )
                         try:
                             # For virl2_client lower than 2.7.0
@@ -194,7 +196,7 @@ def main(
                             )
                 else:
                     # If node is not yet created, we need to create it
-                    log.info(f'[CREATE] Creating node {new_node_definition["id"]}...')
+                    log.info(f"[CREATE] Creating node {new_node_definition['id']}...")
                     cml.definitions.upload_node_definition(
                         new_node_definition, json=True
                     )


### PR DESCRIPTION
fix problem where setup task could fail with IndexError when user has invalid image definitions created manually in CML