### PR TITLE
Fix template attach payload for SD-WAN Manager 20.15

### DIFF
--- a/catalyst_sdwan_lab/tasks/add.py
+++ b/catalyst_sdwan_lab/tasks/add.py
@@ -453,6 +453,7 @@ def main(
                         "//system/system-ip": f"10.0.0.{next_num_str}",
                         "//system/site-id": next_num_str,
                         "csv-templateId": template_id,
+                        "selected": "true",
                     }
                     if ip_type in ["v4", "dual"]:
                         variables_dict["/0/GigabitEthernet1/interface/ip/address"] = (

--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -114,6 +114,7 @@ def attach_basic_controller_template(
                 "//system/system-ip": f"100.0.0.{ip_4th_oct}",
                 "//system/site-id": "100",
                 "csv-templateId": template_id,
+                "selected": "true",
             }
             if ip_type in ["v4", "dual"]:
                 variables["/0/eth1/interface/ip/address"] = f"172.16.0.{ip_4th_oct}/24"


### PR DESCRIPTION
## Summary

Add the missing `selected` field to the `attachfeature` payload used for
controller and edge template attaches.

## Problem

When deploying a lab against SD-WAN Manager 20.15.4.2, the tool could
complete lab creation and onboard the control components, but it failed at
the final controller template attach step with a generic task validation
failure.

In the failing state:

- `vManage`, `vBond`, and `vSmart` were all reachable
- `vSmart` remained unmanaged with no template attached
- rerunning `deploy --retry` failed in the same place

A manual attach against the same Manager instance succeeded once the payload
included:

```json
"selected": "true"
```

The same payload shape is also used in `add.py` for WAN edge attaches, so
the fix is applied in both places.

## Change

- add `selected: "true"` to the controller template attach payload in
  `tasks/utils.py`
- add `selected: "true"` to the WAN edge template attach payload in
  `tasks/add.py`

## Validation

Validated against a live SD-WAN Manager 20.15.4.2 lab in Cisco Modeling
Labs:

- manual controller attach succeeded with the updated payload
- the controller moved from unmanaged to template-attached and in sync
- edge add succeeded with the same payload adjustment
