### PR TITLE
fix: support viptela-* image naming in get_cml_sdwan_image_definition

### DIFF
--- a/catalyst_sdwan_lab/tasks/utils.py
+++ b/catalyst_sdwan_lab/tasks/utils.py
@@ -300,6 +300,12 @@ def get_cml_sdwan_image_definition(
     if requested_image_definition in existing_image_definitions:
         return requested_image_definition
     else:
+        # Fallback: match by version string in image ID.
+        # Handles cases where images were registered manually with viptela-* naming
+        # (e.g. viptela-vmanage-20.12.7.1) instead of the expected cat-sdwan-* convention.
+        version_matches = [img for img in existing_image_definitions if software_version in img]
+        if version_matches:
+            return version_matches[0]
         if node_definition in ["cat-sdwan-controller", "cat-sdwan-validator"]:
             # If there's no requested Controller image, try one version lower
             # For example sometimes Manager is 20.9.3.2 and Controller/Validator is 20.9.3.1


### PR DESCRIPTION
## Problem

When SD-WAN images are registered in CML manually (via the REST API or UI) rather than through `sdwan-lab setup`, they often use the legacy viptela-* naming convention:

- `viptela-vmanage-20.12.7.1`
- `viptela-smart-20.12.7.1`
- `viptela-edge-20.12.7.1-vbond`
- `viptela-edge-20.12.7.1`

The `get_cml_sdwan_image_definition()` function constructs the expected ID as `{node_definition}-{software_version}` (e.g. `cat-sdwan-manager-20.12.7.1`) and does an exact match. If the images exist but use viptela-* IDs, the function raises:

```
Requested SD-WAN Manager software image version 20.12.7.1 is not found in CML.
Use setup task to upload the correct images or use any available image: []
```

The `[]` is misleading — the images **are** present, just under different IDs. The function finds zero available versions because it only lists IDs for the correct `node_definition_id`, then tries to parse versions using the `cat-sdwan-*` prefix format, which does not match viptela-* IDs.

## Fix

Add a version-string fallback inside the `else` branch. If the exact cat-sdwan-* ID is not found, scan `existing_image_definitions` for any ID containing the requested `software_version` string. This matches viptela-* IDs (which embed the version number) as well as any other non-standard naming that includes the version.

The fallback only activates when the primary exact match fails, so there is no behaviour change for standard deployments.

## Testing

Validated in production: CML 2.10.0 with SD-WAN images registered using viptela-* IDs. `sdwan-lab deploy 20.12.7.1` successfully finds all four image definitions (vManage, vSmart, vBond, vEdge) and proceeds to full lab deployment.

## Notes

- Non-breaking: exact match is still tried first; fallback only runs on miss
- The fix applies equally to all four SD-WAN node types
- Existing controller/validator version-decrement logic is preserved for the case where neither check succeeds
