### PR TITLE
fix image resolver to support dashed versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Catalyst SD-WAN Lab 3.0.1 [unreleased]
+
+- Fix issue where `deploy`, `add`, and `restore` tasks fail to find software images when CML image IDs use dashes instead of dots (e.g. `20-18-2-1` instead of `20.18.2.1`)
+
 # Catalyst SD-WAN Lab 3.0.0 [Jun 22, 2026]
 
 Complete rewrite. The tool is now dependency-minimal with no catalystwan SDK, no pyATS, and no pyOpenSSL.

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -175,6 +175,13 @@ def resolve_image(cml: ClientLibrary, node_type: str, version: str) -> str:
     # CML image IDs sometimes use zero-padded segments (26.01.01); accept un-padded input too
     if normalized != version and f"{node_type}-{normalized}" in available:
         return f"{node_type}-{normalized}"
+    # CML image IDs sometimes use dashes instead of dots (e.g. 20-18-2-1)
+    dash_version = version.replace(".", "-")
+    if f"{node_type}-{dash_version}" in available:
+        return f"{node_type}-{dash_version}"
+    normalized_dash = normalized.replace(".", "-")
+    if normalized_dash != dash_version and f"{node_type}-{normalized_dash}" in available:
+        return f"{node_type}-{normalized_dash}"
     if node_type in ("cat-sdwan-controller", "cat-sdwan-validator"):
         parts = version.split(".")
         if len(parts) == 4 and parts[-1] == "1":
@@ -182,10 +189,10 @@ def resolve_image(cml: ClientLibrary, node_type: str, version: str) -> str:
         else:
             parts[-1] = str(int(parts[-1]) - 1)
             fallback_version = ".".join(parts)
-        fallback = f"{node_type}-{fallback_version}"
-        if fallback in available:
-            log.debug("%s: exact version not found, using %s", node_type, fallback)
-            return fallback
+        for fv in (fallback_version, fallback_version.replace(".", "-")):
+            if f"{node_type}-{fv}" in available:
+                log.debug("%s: exact version not found, using %s", node_type, fv)
+                return f"{node_type}-{fv}"
     label = node_type.split("-")[2].title()
     versions = [img_id[len(node_type) + 1:] for img_id in available]
     log.error(

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -102,6 +102,10 @@ class TestResolveImage:
         with pytest.raises(Exit):
             resolve_image(cml, "cat-sdwan-manager", "20.15.2")
 
+    def test_dash_separated_version(self) -> None:
+        cml = self._make_cml(["cat-sdwan-manager-20-18-2-1"])
+        assert resolve_image(cml, "cat-sdwan-manager", "20.18.2.1") == "cat-sdwan-manager-20-18-2-1"
+
     def test_no_available_images_exits(self) -> None:
         cml = self._make_cml([])
         with pytest.raises(Exit):


### PR DESCRIPTION
## Description

Fix issue where `deploy`, `add`, and `restore` tasks fail to find software images when CML image IDs use dashes instead of dots (e.g. `20-18-2-1` instead of `20.18.2.1`)