### PR TITLE
Add optional MCP server + stream task progress via log events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
   - Certificates signed automatically after each node reaches Ready state (enterprise and Cisco PKI)
 - Update `backup` to capture cluster node personas from the live cluster management API and embed them in each Manager's backed-up cloud-init
 - Update `restore` to re-enroll secondary Manager nodes into the cluster after Sastre restore
-- Refactor progress reporting across all tasks to use a shared `task_progress` context manager and `make_updater` helper; every spinner update now also emits a `log.info` event, making task progress visible to log consumers (e.g. MCP server)
+- Refactor progress reporting across all tasks to use a shared `task_progress` context manager and `make_updater` helper; every spinner update now also emits a `log.info` event, making task progress visible to log consumers
+- Add optional MCP server (`pip install catalyst-sdwan-lab[mcp]`, entry point `csdwan-mcp`)
+  - Exposes all tasks as MCP tools an LLM agent (VS Code Copilot, opencode, …) can drive conversationally
+  - Long-running tools (deploy, add_devices, restore, images_upload) run as background jobs and return a `job_id` immediately; agent polls progress via `job_status`
 
 # Catalyst SD-WAN Lab 3.0.1 [Jun 24, 2026]
 

--- a/README.md
+++ b/README.md
@@ -385,11 +385,89 @@ csdwan sign [OPTIONS] <csr-file>
 
 ---
 
+## MCP Server (optional)
+
+An optional [Model Context Protocol](https://modelcontextprotocol.io) server lets an LLM agent (VS Code Copilot, opencode, Claude Desktop, …) drive your SD-WAN lab conversationally — deploy a lab, add devices, run a backup, all through natural language.
+
+### Installing with MCP support
+
+```sh
+uv tool install "catalyst-sdwan-lab[mcp]"
+```
+
+Or with pip:
+
+```sh
+pip install "catalyst-sdwan-lab[mcp]"
+```
+
+### Starting the server
+
+```sh
+csdwan-mcp
+```
+
+The server reads credentials from the same environment variables as the CLI (`CML_IP`, `CML_USER`, `CML_PASSWORD`, `LAB_NAME`, `MANAGER_USER`, `MANAGER_PASSWORD`).
+
+### Configuring VS Code Copilot
+
+Add to your `.vscode/mcp.json` (or user settings):
+
+```json
+{
+  "servers": {
+    "sdwan-lab": {
+      "type": "stdio",
+      "command": "csdwan-mcp",
+      "env": {
+        "CML_IP": "your-cml-host",
+        "CML_USER": "admin",
+        "CML_PASSWORD": "...",
+        "LAB_NAME": "my-lab",
+        "MANAGER_USER": "sdwan",
+        "MANAGER_PASSWORD": "..."
+      }
+    }
+  }
+}
+```
+
+### Configuring OpenCode
+
+Add to your `opencode.json` (`~/.config/opencode/opencode.json` globally, or `<project>/.opencode/opencode.json` per-project):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "sdwan-lab": {
+      "type": "local",
+      "command": ["csdwan-mcp"],
+      "enabled": true,
+      "environment": {
+        "CML_IP": "your-cml-host",
+        "CML_USER": "admin",
+        "CML_PASSWORD": "...",
+        "LAB_NAME": "my-lab",
+        "MANAGER_USER": "sdwan",
+        "MANAGER_PASSWORD": "..."
+      }
+    }
+  }
+}
+```
+
+### Background jobs
+
+Long-running tools (`deploy`, `add_devices`, `restore_lab`, `images_upload`) return a `job_id` immediately. Use `job_status(job_id=...)` to poll for progress events and the final result. Short operations (`setup`, `delete_lab`, `backup_lab`, `sign_csr`) block until complete and stream progress inline.
+
+---
+
 ## Limitations and Scale
 
 Per CML lab:
 
-- 1 SD-WAN Manager (cluster not supported)
+- 6 SD-WAN Managers
 - 8 SD-WAN Validators
 - 12 SD-WAN Controllers
 - 20 SD-WAN Edges

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,13 @@ dependencies = [
     "cisco-sdwan>=1.28",
 ]
 
+[project.optional-dependencies]
+mcp = ["mcp[cli]>=1.0.0"]
+
 [project.scripts]
 sdwan-lab = "catalyst_sdwan_lab.cli:app"
 csdwan = "catalyst_sdwan_lab.cli:app"
+csdwan-mcp = "catalyst_sdwan_lab.mcp_server:main"
 
 [build-system]
 requires = ["uv_build>=0.11.22,<0.12"]
@@ -43,4 +47,5 @@ dev = [
     "pytest>=9.1.1",
     "ruff>=0.15.18",
     "websocket-client>=1.9.0",
+    "mcp[cli]>=1.0.0",
 ]

--- a/src/catalyst_sdwan_lab/_mcp_adapter.py
+++ b/src/catalyst_sdwan_lab/_mcp_adapter.py
@@ -1,0 +1,355 @@
+"""
+Adapter layer for running CLI task functions in MCP context.
+
+Handles:
+- Catching typer.Exit (used for flow control in task modules) and converting
+  to a textual error result instead of terminating the process.
+- Capturing Rich console output so it can be returned as tool result text.
+- Streaming log messages as MCP notifications in real-time via Context.
+- Running long tasks as background jobs whose buffered events can be pulled
+  into the agent's context via repeated job_status polls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import sys
+import threading
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from queue import Empty, SimpleQueue
+from typing import Any
+
+import typer
+from mcp.server.fastmcp import Context
+from rich.console import Console
+
+
+class _StreamingLogHandler(logging.Handler):
+    """Pushes log records into a queue for async consumption."""
+
+    def __init__(self, queue: SimpleQueue[str | None]) -> None:
+        super().__init__()
+        self.queue = queue
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.queue.put(self.format(record))
+
+
+def _patch_task_consoles(capture_console: Console) -> list[tuple[object, str, Any]]:
+    """Redirect any already-imported task module console references."""
+    patched: list[tuple[object, str, Any]] = []
+    for module_name, module in list(sys.modules.items()):
+        if not module_name.startswith("catalyst_sdwan_lab.tasks"):
+            continue
+        if module is None or not hasattr(module, "console"):
+            continue
+        original_console = getattr(module, "console")
+        setattr(module, "console", capture_console)
+        patched.append((module, "console", original_console))
+    return patched
+
+
+def _restore_patched_values(patched: list[tuple[object, str, Any]]) -> None:
+    for module, attr_name, original_value in reversed(patched):
+        setattr(module, attr_name, original_value)
+
+
+def _run_task_in_thread(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    queue: SimpleQueue[str | None],
+) -> tuple[str | None, BaseException | None]:
+    """Run the task function synchronously in a thread, capturing output."""
+    import catalyst_sdwan_lab.tasks.utils as utils
+
+    buf = io.StringIO()
+    original_console = utils.console
+    capture_console = Console(file=buf, width=120, no_color=True)
+    utils.console = capture_console
+    patched = _patch_task_consoles(capture_console)
+
+    handler = _StreamingLogHandler(queue)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger = logging.getLogger("catalyst_sdwan_lab")
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+
+    error: BaseException | None = None
+    try:
+        fn(*args, **kwargs)
+    except BaseException as e:
+        error = e
+    finally:
+        utils.console = original_console
+        _restore_patched_values(patched)
+        root_logger.removeHandler(handler)
+        queue.put(None)  # sentinel
+
+    console_output = buf.getvalue().strip()
+    return console_output, error
+
+
+async def capture_task_async(
+    ctx: Context, fn: Callable[..., Any], *args: Any, **kwargs: Any
+) -> str:
+    """
+    Run a task function and stream progress via MCP notifications.
+
+    - Sends log messages as ctx.info() notifications in real-time.
+    - Returns the final result/error as a string.
+    """
+    queue: SimpleQueue[str | None] = SimpleQueue()
+
+    loop = asyncio.get_event_loop()
+    future = loop.run_in_executor(
+        None, _run_task_in_thread, fn, args, kwargs, queue
+    )
+
+    # Drain the queue, forwarding messages to the MCP client as they arrive
+    step = 0
+    while True:
+        # Poll the queue without blocking the event loop
+        try:
+            msg = queue.get_nowait()
+        except Empty:
+            # Check if the thread is done
+            if future.done():
+                # Drain remaining messages
+                while True:
+                    try:
+                        msg = queue.get_nowait()
+                    except Empty:
+                        break
+                    if msg is None:
+                        break
+                    step += 1
+                    await ctx.report_progress(step, message=msg)
+                break
+            await asyncio.sleep(0.1)
+            continue
+
+        if msg is None:
+            break
+        step += 1
+        await ctx.report_progress(step, message=msg)
+
+    console_output, error = await future
+
+    if error is None:
+        return console_output if console_output else "Done."
+    elif isinstance(error, typer.Exit):
+        error_text = console_output or f"Task exited with code {error.exit_code}"
+        if error.exit_code != 0:
+            return f"Error: {error_text}"
+        return error_text
+    else:
+        import traceback
+
+        tb = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+        return f"Error: {type(error).__name__}: {error}\n{tb}"
+
+
+def capture_task(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
+    """
+    Synchronous fallback for running tasks without MCP context.
+    Used when no Context is available.
+    """
+    import catalyst_sdwan_lab.tasks.utils as utils
+
+    buf = io.StringIO()
+    original_console = utils.console
+    capture_console = Console(file=buf, width=120, no_color=True)
+    utils.console = capture_console
+    patched = _patch_task_consoles(capture_console)
+
+    log_records: list[str] = []
+
+    class _LogCapture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            log_records.append(self.format(record))
+
+    handler = _LogCapture()
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger = logging.getLogger("catalyst_sdwan_lab")
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+
+    try:
+        fn(*args, **kwargs)
+        console_output = buf.getvalue().strip()
+        parts = [p for p in ["\n".join(log_records), console_output] if p]
+        return "\n".join(parts) if parts else "Done."
+    except typer.Exit as e:
+        console_output = buf.getvalue().strip()
+        parts = [p for p in ["\n".join(log_records), console_output] if p]
+        error_text = "\n".join(parts) if parts else f"Task exited with code {e.exit_code}"
+        if e.exit_code != 0:
+            return f"Error: {error_text}"
+        return error_text
+    except Exception as e:
+        import traceback
+
+        return f"Error: {type(e).__name__}: {e}\n{traceback.format_exc()}"
+    finally:
+        utils.console = original_console
+        _restore_patched_values(patched)
+        root_logger.removeHandler(handler)
+
+
+# ---------------------------------------------------------------------------
+# Background job model
+#
+# Long-running tasks (deploy, restore, add_devices, images_upload) cannot
+# stream into the agent's context, because an MCP tool's only channel to the
+# agent is its return value — delivered once, when the call completes.
+#
+# To surface progress (and interactive prompts such as the Cisco PKI
+# registration URL) WHILE the task runs, we run the task in a background
+# thread and let the agent pull buffered log events through repeated
+# job_status() calls. Each poll long-polls server-side until a new event or a
+# status change occurs, so polling stays cheap and responsive.
+# ---------------------------------------------------------------------------
+
+
+def _finalize_result(
+    console_output: str, error: BaseException | None
+) -> tuple[str, str]:
+    """Map a finished task to (status, result_text). status is 'done' or 'error'."""
+    if error is None:
+        return "done", console_output or "Done."
+    if isinstance(error, typer.Exit):
+        text = console_output or f"Task exited with code {error.exit_code}"
+        if error.exit_code not in (0, None):
+            return "error", f"Error: {text}"
+        return "done", text
+    import traceback
+
+    tb = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    return "error", f"Error: {type(error).__name__}: {error}\n{tb}"
+
+
+@dataclass
+class _Job:
+    """A background task whose events the agent pulls via job_status."""
+
+    id: str
+    label: str
+    status: str = "running"  # running | done | error
+    events: list[str] = field(default_factory=list)
+    delivered: int = 0
+    result: str | None = None
+    _cond: threading.Condition = field(default_factory=threading.Condition)
+
+    def emit(self, msg: str) -> None:
+        with self._cond:
+            self.events.append(msg)
+            self._cond.notify_all()
+
+    def finish(self, status: str, result: str) -> None:
+        with self._cond:
+            self.status = status
+            self.result = result
+            self._cond.notify_all()
+
+    def wait_and_drain(self, timeout: float) -> tuple[list[str], str, str | None]:
+        """Block up to timeout for new events / completion, then drain new events."""
+        with self._cond:
+            if self.delivered >= len(self.events) and self.status == "running":
+                self._cond.wait(timeout)
+            new = self.events[self.delivered :]
+            self.delivered = len(self.events)
+            return new, self.status, self.result
+
+
+class _JobLogHandler(logging.Handler):
+    """Routes log records emitted during a job into that job's event buffer."""
+
+    def __init__(self, job: _Job) -> None:
+        super().__init__()
+        self.job = job
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.job.emit(self.format(record))
+
+
+_JOBS: dict[str, _Job] = {}
+_JOBS_LOCK = threading.Lock()
+
+
+def _job_worker(
+    job: _Job, fn: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> None:
+    import catalyst_sdwan_lab.tasks.utils as utils
+
+    buf = io.StringIO()
+    original_console = utils.console
+    capture_console = Console(file=buf, width=120, no_color=True)
+    utils.console = capture_console
+    patched = _patch_task_consoles(capture_console)
+
+    handler = _JobLogHandler(job)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root_logger = logging.getLogger("catalyst_sdwan_lab")
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)
+
+    error: BaseException | None = None
+    try:
+        fn(*args, **kwargs)
+    except BaseException as e:  # noqa: BLE001 - surfaced via job result
+        error = e
+    finally:
+        utils.console = original_console
+        _restore_patched_values(patched)
+        root_logger.removeHandler(handler)
+
+    status, result = _finalize_result(buf.getvalue().strip(), error)
+    job.finish(status, result)
+
+
+def start_job(label: str, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> str:
+    """Start a task in a background thread and return its job id."""
+    job = _Job(id=uuid.uuid4().hex[:8], label=label)
+    with _JOBS_LOCK:
+        _JOBS[job.id] = job
+    thread = threading.Thread(
+        target=_job_worker, args=(job, fn, args, kwargs), daemon=True
+    )
+    thread.start()
+    return job.id
+
+
+async def poll_job(job_id: str, timeout: float = 15.0) -> str:
+    """Long-poll a job: wait for new events/completion, return them as text."""
+    with _JOBS_LOCK:
+        job = _JOBS.get(job_id)
+    if job is None:
+        return f"status: unknown\nError: no job with id '{job_id}'"
+
+    loop = asyncio.get_event_loop()
+    new, status, result = await loop.run_in_executor(
+        None, job.wait_and_drain, timeout
+    )
+
+    lines = [f"job_id: {job_id}", f"status: {status}"]
+    if new:
+        lines.append("events:")
+        lines.extend(f"  {e}" for e in new)
+    elif status == "running":
+        lines.append("(no new events yet — keep polling)")
+    if status in ("done", "error") and result is not None:
+        lines.append("result:")
+        lines.append(result)
+        with _JOBS_LOCK:
+            _JOBS.pop(job_id, None)
+    return "\n".join(lines)
+
+

--- a/src/catalyst_sdwan_lab/_mcp_adapter.py
+++ b/src/catalyst_sdwan_lab/_mcp_adapter.py
@@ -271,12 +271,14 @@ class _Job:
 class _JobLogHandler(logging.Handler):
     """Routes log records emitted during a job into that job's event buffer."""
 
-    def __init__(self, job: _Job) -> None:
+    def __init__(self, job: _Job, thread_id: int) -> None:
         super().__init__()
         self.job = job
+        self._thread_id = thread_id
 
     def emit(self, record: logging.LogRecord) -> None:
-        self.job.emit(self.format(record))
+        if record.thread == self._thread_id:
+            self.job.emit(self.format(record))
 
 
 _JOBS: dict[str, _Job] = {}
@@ -294,7 +296,7 @@ def _job_worker(
     utils.console = capture_console
     patched = _patch_task_consoles(capture_console)
 
-    handler = _JobLogHandler(job)
+    handler = _JobLogHandler(job, threading.current_thread().ident or 0)
     handler.setLevel(logging.INFO)
     handler.setFormatter(logging.Formatter("%(message)s"))
     root_logger = logging.getLogger("catalyst_sdwan_lab")

--- a/src/catalyst_sdwan_lab/mcp_server.py
+++ b/src/catalyst_sdwan_lab/mcp_server.py
@@ -221,6 +221,7 @@ async def add_devices(
     lab_name: str,
     manager_password: str,
     manager_user: str = "admin",
+    persona: str = "compute-and-data",
     cpus: int | None = None,
     ram: int | None = None,
     cml_host: str | None = None,
@@ -231,16 +232,18 @@ async def add_devices(
     Add and onboard SD-WAN devices to an existing lab.
 
     Detects the lab's IP type (v4/v6/dual) automatically.
-    This is a long-running operation for edge devices (boots VMs, generates
-    certificates, waits for onboarding).
+    This is a long-running operation for edge devices and managers (boots VMs,
+    generates certificates, waits for onboarding).
 
     Args:
         count: Number of devices to add (minimum 1)
-        device_type: One of "controller", "validator", "edge", "sdrouting"
+        device_type: One of "manager", "controller", "validator", "edge", "sdrouting"
         version: SD-WAN software version (e.g. "20.15.1")
         lab_name: Name of the existing CML lab
         manager_password: SD-WAN Manager password
         manager_user: Manager username (default: "admin")
+        persona: Manager cluster persona — "compute-and-data" (default), "compute", or "data"
+                 Only applies when device_type is "manager"
         cpus: Override number of CPUs per node
         ram: Override RAM in MB per node
         cml_host: CML hostname or IP (or set CML_IP env var)
@@ -249,7 +252,7 @@ async def add_devices(
     """
     host, user, password = _cml_creds(cml_host, cml_user, cml_password)
 
-    valid_types = {"controller", "validator", "edge", "sdrouting"}
+    valid_types = {"manager", "controller", "validator", "edge", "sdrouting"}
     device = device_type.lower().rstrip("s")  # allow plurals
     if device not in valid_types:
         valid = ", ".join(sorted(valid_types))
@@ -257,7 +260,26 @@ async def add_devices(
     if count < 1:
         return "Error: count must be at least 1."
 
-    if device in ("controller", "validator"):
+    valid_personas = {"compute-and-data", "compute", "data"}
+    if persona not in valid_personas:
+        return f"Error: Unknown persona '{persona}'. Valid: {', '.join(sorted(valid_personas))}"
+
+    if device == "manager":
+        from .cli import ManagerPersona
+        job_id = start_job(
+            "add_devices",
+            _add.run_managers,
+            host, user, password,
+            lab_name=lab_name,
+            version=version,
+            manager_user=manager_user,
+            manager_password=manager_password,
+            count=count,
+            persona=ManagerPersona(persona).to_api_value(),
+            cpus=cpus,
+            ram=ram,
+        )
+    elif device in ("controller", "validator"):
         job_id = start_job(
             "add_devices",
             _add.run_control_component,

--- a/src/catalyst_sdwan_lab/mcp_server.py
+++ b/src/catalyst_sdwan_lab/mcp_server.py
@@ -1,0 +1,578 @@
+"""
+Catalyst SD-WAN Lab – MCP Server
+
+Exposes the tool's capabilities as MCP tools so that an LLM-based agent
+can deploy, manage, and query SD-WAN labs in CML conversationally.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from mcp.server.fastmcp import Context, FastMCP
+
+from catalyst_sdwan_lab.tasks import add as _add
+from catalyst_sdwan_lab.tasks import backup as _backup
+from catalyst_sdwan_lab.tasks import delete as _delete
+from catalyst_sdwan_lab.tasks import deploy as _deploy
+from catalyst_sdwan_lab.tasks import images as _images
+from catalyst_sdwan_lab.tasks import restore as _restore
+from catalyst_sdwan_lab.tasks import setup as _setup
+from catalyst_sdwan_lab.tasks import sign as _sign
+from catalyst_sdwan_lab.tasks.utils import DEFAULT_SERIAL_FILE
+
+from ._mcp_adapter import capture_task_async, poll_job, start_job
+
+log = logging.getLogger(__name__)
+
+mcp = FastMCP(
+    "catalyst-sdwan-lab",
+    instructions=(
+        "Automates Cisco Catalyst SD-WAN lab deployment and management inside "
+        "Cisco Modeling Labs (CML). Provides tools to deploy full control-plane "
+        "topologies, add edge devices, manage software images, back up and "
+        "restore labs, and more.\n\n"
+        "Key workflow: setup (once) → deploy → add_devices.\n"
+        "Two connectivity modes: PATty (manager_port) or Direct (manager_ip + mask + gateway).\n"
+        "Always confirm with the user before calling delete_lab.\n\n"
+        "IMPORTANT — long-running tools run as BACKGROUND JOBS. deploy, restore, "
+        "add_devices, and images_upload return immediately with a job_id instead "
+        "of blocking until completion. To follow progress, repeatedly call "
+        "job_status(job_id=...): each call long-polls and returns the log events "
+        "that occurred since your last poll, plus the final result once status is "
+        "'done' or 'error'. Keep polling until the job finishes.\n"
+        "Some jobs surface ACTION REQUIRED events mid-run (e.g. Cisco PKI "
+        "registration prints a URL the user must open in a browser). Relay such "
+        "events to the user as soon as job_status returns them, then continue "
+        "polling — the job resumes automatically once the user completes the action."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _started(label: str, job_id: str) -> str:
+    """Standard response when a long-running tool is dispatched as a background job."""
+    return (
+        f"Started background job '{job_id}' ({label}). It runs asynchronously; "
+        f"results are NOT returned by this call. Call job_status(job_id=\"{job_id}\") "
+        f"to stream progress events and retrieve the final result. Poll repeatedly "
+        f"until status is 'done' or 'error'. Watch for ACTION REQUIRED events and "
+        f"relay them to the user immediately."
+    )
+
+
+def _cml_creds(
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> tuple[str, str, str]:
+    """Resolve CML credentials from arguments or environment variables."""
+    host = cml_host or os.environ.get("CML_IP", "")
+    user = cml_user or os.environ.get("CML_USER", "")
+    password = cml_password or os.environ.get("CML_PASSWORD", "")
+    if not host:
+        raise ValueError("CML host is required (pass cml_host or set CML_IP env var)")
+    if not user:
+        raise ValueError("CML user is required (pass cml_user or set CML_USER env var)")
+    if not password:
+        raise ValueError("CML password is required (pass cml_password or set CML_PASSWORD env var)")
+    return host, user, password
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def setup(
+    ctx: Context,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Prepare CML for SD-WAN lab deployment.
+
+    Creates the required SD-WAN node definitions in CML. Run this once after
+    installing the tool and after upgrades.
+
+    Args:
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    return await capture_task_async(ctx, _setup.run, host, user, password)
+
+
+@mcp.tool()
+async def deploy(
+    ctx: Context,
+    version: str,
+    manager_password: str,
+    lab_name: str,
+    manager_port: int | None = None,
+    manager_ip: str | None = None,
+    manager_mask: str | None = None,
+    manager_gateway: str | None = None,
+    manager_user: str = "admin",
+    bridge: str | None = None,
+    dns_server: str = "192.168.255.1",
+    ip_type: str = "v4",
+    retry: bool = False,
+    serial_file: str | None = None,
+    pki: str = "enterprise",
+    proxy_ip: str = "",
+    proxy_port: str = "80",
+    no_proxy: str = "",
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Deploy a complete Catalyst SD-WAN lab in CML.
+
+    Creates a CML topology with INET/MPLS underlay, Manager, Validator,
+    Controller, and a Gateway router. Then waits for all nodes to boot and
+    configures the SD-WAN control plane (certificates, onboarding, templates).
+
+    This is a long-running operation (5-15 minutes typically).
+
+    Connectivity modes:
+    - PATty mode: provide manager_port (Manager accessed via CML port mapping)
+    - Direct mode: provide manager_ip, manager_mask, and manager_gateway
+
+    Args:
+        version: SD-WAN software version (e.g. "20.15.1")
+        manager_password: SD-WAN Manager password (must not be "admin")
+        lab_name: Name for the CML lab
+        manager_port: PATty external port (enables PATty mode)
+        manager_ip: Manager IP address (direct mode)
+        manager_mask: Subnet mask e.g. "/24" (direct mode)
+        manager_gateway: Default gateway (direct mode)
+        manager_user: Manager username (default: "admin")
+        bridge: CML bridge name (direct mode, default: "System Bridge")
+        dns_server: DNS server for lab nodes (default: "192.168.255.1")
+        ip_type: Overlay IP type: "v4", "v6", or "dual"
+        retry: Resume Manager onboarding without recreating the lab
+        serial_file: Path to custom .viptela serial file
+        pki: Certificate signing mode: "enterprise" or "cisco"
+        proxy_ip: HTTP proxy hostname or IP
+        proxy_port: HTTP proxy port (default: "80")
+        no_proxy: Additional no-proxy entries
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+
+    patty = manager_port is not None
+    if patty and any([manager_ip, manager_mask, manager_gateway, bridge]):
+        return (
+            "Error: manager_port (PATty mode) cannot be combined with "
+            "manager_ip/mask/gateway/bridge."
+        )
+    if not patty and not all([manager_ip, manager_mask, manager_gateway]):
+        return (
+            "Error: Provide manager_port for PATty mode, or all of "
+            "manager_ip + manager_mask + manager_gateway for direct mode."
+        )
+
+    job_id = start_job(
+        "deploy",
+        _deploy.run,
+        cml_host=host,
+        cml_user=user,
+        cml_password=password,
+        manager_ip=host if patty else manager_ip or "",
+        manager_port=manager_port or 443,
+        manager_user=manager_user,
+        manager_password=manager_password,
+        manager_mask=manager_mask or "",
+        manager_gateway=manager_gateway or "",
+        version=version,
+        lab_name=lab_name,
+        bridge=bridge or "System Bridge",
+        dns_server=dns_server,
+        ip_type=ip_type,
+        retry=retry,
+        patty=patty,
+        serial_file=Path(serial_file) if serial_file else DEFAULT_SERIAL_FILE,
+        pki=pki,
+        proxy_ip=proxy_ip,
+        proxy_port=proxy_port,
+        no_proxy=no_proxy,
+    )
+    return _started("deploy", job_id)
+
+
+@mcp.tool()
+async def add_devices(
+    ctx: Context,
+    count: int,
+    device_type: str,
+    version: str,
+    lab_name: str,
+    manager_password: str,
+    manager_user: str = "admin",
+    cpus: int | None = None,
+    ram: int | None = None,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Add and onboard SD-WAN devices to an existing lab.
+
+    Detects the lab's IP type (v4/v6/dual) automatically.
+    This is a long-running operation for edge devices (boots VMs, generates
+    certificates, waits for onboarding).
+
+    Args:
+        count: Number of devices to add (minimum 1)
+        device_type: One of "controller", "validator", "edge", "sdrouting"
+        version: SD-WAN software version (e.g. "20.15.1")
+        lab_name: Name of the existing CML lab
+        manager_password: SD-WAN Manager password
+        manager_user: Manager username (default: "admin")
+        cpus: Override number of CPUs per node
+        ram: Override RAM in MB per node
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+
+    valid_types = {"controller", "validator", "edge", "sdrouting"}
+    device = device_type.lower().rstrip("s")  # allow plurals
+    if device not in valid_types:
+        valid = ", ".join(sorted(valid_types))
+        return f"Error: Unknown device_type '{device_type}'. Valid: {valid}"
+    if count < 1:
+        return "Error: count must be at least 1."
+
+    if device in ("controller", "validator"):
+        job_id = start_job(
+            "add_devices",
+            _add.run_control_component,
+            host, user, password,
+            lab_name=lab_name,
+            version=version,
+            manager_user=manager_user,
+            manager_password=manager_password,
+            count=count,
+            device_type=device,
+            cpus=cpus,
+            ram=ram,
+        )
+    elif device == "edge":
+        job_id = start_job(
+            "add_devices",
+            _add.run_edge,
+            host, user, password,
+            lab_name=lab_name,
+            version=version,
+            manager_user=manager_user,
+            manager_password=manager_password,
+            count=count,
+            cpus=cpus,
+            ram=ram,
+        )
+    else:  # sdrouting
+        job_id = start_job(
+            "add_devices",
+            _add.run_sdrouting,
+            host, user, password,
+            lab_name=lab_name,
+            version=version,
+            manager_user=manager_user,
+            manager_password=manager_password,
+            count=count,
+            cpus=cpus,
+            ram=ram,
+        )
+    return _started("add_devices", job_id)
+
+
+@mcp.tool()
+async def delete_lab(
+    ctx: Context,
+    lab_name: str,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Delete a Catalyst SD-WAN lab from CML.
+
+    Stops, wipes, and removes the lab. This is destructive and irreversible.
+
+    Args:
+        lab_name: Name of the CML lab to delete
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    # Force=True because the LLM has already confirmed with the user
+    return await capture_task_async(ctx, _delete.run, host, user, password, lab_name, force=True)
+
+
+@mcp.tool()
+async def backup_lab(
+    ctx: Context,
+    lab_name: str,
+    manager_password: str,
+    manager_user: str = "admin",
+    output: str | None = None,
+    directory: bool = False,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Back up a running SD-WAN lab (topology + Manager configuration).
+
+    Args:
+        lab_name: Name of the CML lab
+        manager_password: SD-WAN Manager password
+        manager_user: Manager username (default: "admin")
+        output: Output path (default: <lab>-<date>.zip)
+        directory: Save as unpacked directory instead of zip
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    return await capture_task_async(
+        ctx,
+        _backup.run,
+        host, user, password,
+        lab_name=lab_name,
+        manager_user=manager_user,
+        manager_password=manager_password,
+        output=Path(output) if output else None,
+        directory=directory,
+    )
+
+
+@mcp.tool()
+async def restore_lab(
+    ctx: Context,
+    backup_path: str,
+    lab_name: str,
+    manager_password: str,
+    manager_port: int | None = None,
+    manager_ip: str | None = None,
+    manager_mask: str | None = None,
+    manager_gateway: str | None = None,
+    manager_user: str = "admin",
+    serial_file: str | None = None,
+    control_version: str | None = None,
+    edge_version: str | None = None,
+    delete_existing: bool = False,
+    retry: bool = False,
+    pki: str = "enterprise",
+    proxy_ip: str = "",
+    proxy_port: str = "80",
+    no_proxy: str = "",
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Restore a Catalyst SD-WAN lab from a backup archive.
+
+    Args:
+        backup_path: Path to backup zip file or directory
+        lab_name: Name for the restored lab
+        manager_password: SD-WAN Manager password
+        manager_port: PATty external port (enables PATty mode)
+        manager_ip: Manager IP address (direct mode)
+        manager_mask: Subnet mask (direct mode)
+        manager_gateway: Default gateway (direct mode)
+        manager_user: Manager username (default: "admin")
+        serial_file: Path to custom .viptela serial file
+        control_version: Override control plane version
+        edge_version: Override edge version
+        delete_existing: Delete existing lab with same name before restoring
+        retry: Resume from Manager boot, skipping lab import
+        pki: Certificate signing mode: "enterprise" or "cisco"
+        proxy_ip: HTTP proxy hostname or IP
+        proxy_port: HTTP proxy port
+        no_proxy: Additional no-proxy entries
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+
+    patty = manager_port is not None
+    if not patty and not all([manager_ip, manager_mask, manager_gateway]):
+        return (
+            "Error: Provide manager_port for PATty mode, or all of "
+            "manager_ip + manager_mask + manager_gateway for direct mode."
+        )
+
+    job_id = start_job(
+        "restore_lab",
+        _restore.run,
+        cml_host=host,
+        cml_user=user,
+        cml_password=password,
+        lab_name=lab_name,
+        manager_user=manager_user,
+        manager_password=manager_password,
+        manager_ip=host if patty else manager_ip or "",
+        manager_port=manager_port or 443,
+        manager_mask=manager_mask or "",
+        manager_gateway=manager_gateway or "",
+        backup=Path(backup_path),
+        serial_file=Path(serial_file) if serial_file else DEFAULT_SERIAL_FILE,
+        control_version=control_version,
+        edge_version=edge_version,
+        delete_existing=delete_existing,
+        retry=retry,
+        patty=patty,
+        pki=pki,
+        proxy_ip=proxy_ip,
+        proxy_port=proxy_port,
+        no_proxy=no_proxy,
+    )
+    return _started("restore_lab", job_id)
+
+
+@mcp.tool()
+async def images_list(
+    ctx: Context,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    List SD-WAN software versions installed in CML.
+
+    Returns a table of node types and their available software versions.
+
+    Args:
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    return await capture_task_async(ctx, _images.list_versions, host, user, password)
+
+
+@mcp.tool()
+async def images_upload(
+    ctx: Context,
+    images_dir: str = ".",
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Upload SD-WAN .qcow2 image files to CML.
+
+    Scans the specified directory for recognized SD-WAN image files and
+    uploads them with the correct image definitions.
+
+    Args:
+        images_dir: Directory containing .qcow2 files (default: current directory)
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    job_id = start_job("images_upload", _images.upload, host, user, password, Path(images_dir))
+    return _started("images_upload", job_id)
+
+
+@mcp.tool()
+async def images_delete(
+    ctx: Context,
+    versions: list[str],
+    dry_run: bool = False,
+    cml_host: str | None = None,
+    cml_user: str | None = None,
+    cml_password: str | None = None,
+) -> str:
+    """
+    Delete SD-WAN image definitions and files from CML.
+
+    Args:
+        versions: List of software versions to delete (e.g. ["20.12.1"])
+        dry_run: If true, show what would be deleted without actually deleting
+        cml_host: CML hostname or IP (or set CML_IP env var)
+        cml_user: CML username (or set CML_USER env var)
+        cml_password: CML password (or set CML_PASSWORD env var)
+    """
+    host, user, password = _cml_creds(cml_host, cml_user, cml_password)
+    return await capture_task_async(
+        ctx, _images.delete, host, user, password, versions, dry_run=dry_run
+    )
+
+
+@mcp.tool()
+async def sign_csr(
+    ctx: Context,
+    csr_file: str,
+    output: str | None = None,
+) -> str:
+    """
+    Sign a CSR with the lab CA certificate.
+
+    Returns the signed certificate in PEM format.
+
+    Args:
+        csr_file: Path to the CSR file (.txt or .pem)
+        output: Optional path to write the signed certificate to
+    """
+    return await capture_task_async(
+        ctx,
+        _sign.run,
+        Path(csr_file),
+        Path(output) if output else None,
+    )
+
+
+@mcp.tool()
+async def job_status(
+    ctx: Context,
+    job_id: str,
+) -> str:
+    """
+    Poll a background job started by a long-running tool (deploy, restore,
+    add_devices, images_upload).
+
+    Long-polls server-side: blocks briefly until new log events occur or the
+    job finishes, then returns the events emitted since your last poll plus the
+    job status. Call this repeatedly until status is 'done' or 'error'.
+
+    If an event begins with "ACTION REQUIRED", relay it to the user immediately
+    (e.g. a Cisco PKI registration URL to open in a browser), then keep polling —
+    the job continues automatically once the user completes the action.
+
+    Args:
+        job_id: The job id returned when the long-running tool was started.
+    """
+    return await poll_job(job_id)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """Run the MCP server (stdio transport)."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -276,7 +276,6 @@ def run_edge(
             for node in nodes:
                 update(f"Waiting for {'edges' if count > 1 else 'edge'} to boot...")
                 node.wait_until_converged()
-            log.info("Edges booted; waiting for onboarding...")
 
             update(f"Waiting for edges to onboard (0/{count})...")
             wait_for_edges_onboarded(

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -85,13 +85,16 @@ def run_control_component(
         transient=True,
     ) as progress:
         task = progress.add_task("Connecting to CML...")
+        log.info("Connecting to CML at %s...", cml_host)
         cml = connect_cml(cml_host, cml_user, cml_password)
         progress.update(task, description="Checking lab and images...")
+        log.info("Checking lab '%s' and %s image %s...", lab_name, device_type, version)
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, node_def, version)
 
         progress.update(task, description="Connecting to SD-WAN Manager...")
+        log.info("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
             pki = client.get_certificate_signing()
@@ -111,6 +114,7 @@ def run_control_component(
                     task,
                     description=f"Adding {label_prefix}{num} to CML ({i + 1}/{count})...",
                 )
+                log.info("Adding %s%s to CML (%d/%d)...", label_prefix, num, i + 1, count)
                 extra = (
                     {"controller_num": num, "validator_fqdn": VALIDATOR_FQDN}
                     if is_ctrl
@@ -144,6 +148,7 @@ def run_control_component(
                 _add_to_manager_retrying(client, ip, personality, timeout=_BOOT_TIMEOUT)
 
             progress.update(task, description=f"Waiting for {device_type} CSRs...")
+            log.info("Waiting for %s CSRs and signing certificates...", device_type)
             _wait_for_csrs(client, device_ips, timeout=_CSR_POLL_TIMEOUT)
 
             progress.update(task, description=f"Signing {device_type} certificates...")
@@ -171,6 +176,7 @@ def run_control_component(
                     cml_host, cml_user, cml_password, lab, lab_name, device_ips,
                 )
             progress.update(task, description="Triggering network rediscovery...")
+            log.info("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -205,16 +211,20 @@ def run_edge(
         transient=True,
     ) as progress:
         task = progress.add_task("Connecting to CML...")
+        log.info("Connecting to CML at %s...", cml_host)
         cml = connect_cml(cml_host, cml_user, cml_password)
         progress.update(task, description="Checking lab and images...")
+        log.info("Checking lab '%s' and edge image %s...", lab_name, version)
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, "cat-sdwan-edge", version)
 
         progress.update(task, description="Connecting to SD-WAN Manager...")
+        log.info("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
             progress.update(task, description="Checking available edge devices...")
+            log.info("Checking available edge devices...")
             vedges = client.get_vedges()
             free_uuids = [
                 v["uuid"]
@@ -266,6 +276,7 @@ def run_edge(
                 devices_vars.append({"device-id": uuid, "variables": variables})
 
             progress.update(task, description="Associating config group...")
+            log.info("Deploying edge_basic config group to %d device(s)...", count)
             client.associate_config_group(config_group_id, uuids)
             progress.update(task, description="Setting device variables...")
             client.set_config_group_variables(config_group_id, devices_vars)
@@ -274,6 +285,7 @@ def run_edge(
             client.wait_for_task(task_id)
 
             progress.update(task, description="Fetching bootstrap configs...")
+            log.info("Fetching bootstrap configs and adding edges to CML...")
             bootstrap_configs = {uuid: client.get_bootstrap_config(uuid) for uuid in uuids}
 
             nodes: list[Node] = []
@@ -281,6 +293,7 @@ def run_edge(
                 progress.update(
                     task, description=f"Adding Edge{num} to CML ({i}/{count})..."
                 )
+                log.info("Adding Edge%s to CML (%d/%d)...", num, i, count)
                 node = _add_wan_edge_node(
                     lab, f"Edge{num}", image_id, bootstrap_configs[uuid], True, cpus, ram,
                 )
@@ -292,17 +305,22 @@ def run_edge(
                     task, description=f"Waiting for {'edges' if count > 1 else 'edge'} to boot..."
                 )
                 node.wait_until_converged()
+            log.info("Edges booted; waiting for onboarding...")
 
             progress.update(task, description=f"Waiting for edges to onboard (0/{count})...")
             wait_for_edges_onboarded(
                 client,
                 uuids,
                 timeout=_BOOT_TIMEOUT,
-                on_progress=lambda done, total: progress.update(
-                    task, description=f"Waiting for edges to onboard ({done}/{total})..."
+                on_progress=lambda done, total: (
+                    progress.update(
+                        task, description=f"Waiting for edges to onboard ({done}/{total})..."
+                    ),
+                    log.info("Edges onboarded: %d/%d", done, total),
                 ),
             )
             progress.update(task, description="Triggering network rediscovery...")
+            log.info("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -332,13 +350,16 @@ def run_sdrouting(
         transient=True,
     ) as progress:
         task = progress.add_task("Connecting to CML...")
+        log.info("Connecting to CML at %s...", cml_host)
         cml = connect_cml(cml_host, cml_user, cml_password)
         progress.update(task, description="Checking lab and images...")
+        log.info("Checking lab '%s' and SD-Routing image %s...", lab_name, version)
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, "cat-sdwan-edge", version)
 
         progress.update(task, description="Connecting to SD-WAN Manager...")
+        log.info("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
             progress.update(task, description="Checking available SD-Routing devices...")
@@ -390,6 +411,7 @@ def run_sdrouting(
                 devices_vars.append({"device-id": uuid, "variables": variables})
 
             progress.update(task, description="Associating config group...")
+            log.info("Deploying sdrouting_basic config group to %d device(s)...", count)
             client.associate_config_group(config_group_id, uuids)
             progress.update(task, description="Setting device variables...")
             client.set_config_group_variables(
@@ -400,6 +422,7 @@ def run_sdrouting(
             client.wait_for_task(task_id)
 
             progress.update(task, description="Fetching bootstrap configs...")
+            log.info("Fetching bootstrap configs and adding SD-Routing edges to CML...")
             bootstrap_configs = {
                 uuid: client.get_bootstrap_config(uuid, wanif="GigabitEthernet1")
                 for uuid in uuids
@@ -410,6 +433,7 @@ def run_sdrouting(
                 progress.update(
                     task, description=f"Adding SD-Edge{num} to CML ({i}/{count})..."
                 )
+                log.info("Adding SD-Edge%s to CML (%d/%d)...", num, i, count)
                 node = _add_wan_edge_node(
                     lab, f"SD-Edge{num}", image_id, bootstrap_configs[uuid], False, cpus, ram,
                 )
@@ -426,6 +450,7 @@ def run_sdrouting(
                 ):
                     node.wait_until_converged()
 
+            log.info("SD-Routing edges booted; waiting for onboarding...")
             progress.update(
                 task, description=f"Waiting for SD-Routing edges to onboard (0/{count})..."
             )
@@ -433,12 +458,16 @@ def run_sdrouting(
                 client,
                 uuids,
                 timeout=_BOOT_TIMEOUT,
-                on_progress=lambda done, total: progress.update(
-                    task,
-                    description=f"Waiting for SD-Routing edges to onboard ({done}/{total})...",
+                on_progress=lambda done, total: (
+                    progress.update(
+                        task,
+                        description=f"Waiting for SD-Routing edges to onboard ({done}/{total})...",
+                    ),
+                    log.info("SD-Routing edges onboarded: %d/%d", done, total),
                 ),
             )
             progress.update(task, description="Triggering network rediscovery...")
+            log.info("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -142,7 +142,7 @@ def run(
                     proxy_ip=proxy_ip, proxy_port=proxy_port, no_proxy=no_proxy,
                 )
 
-                log.info("[6/11] Onboarding control components (validator, controller)...")
+                update("Adding control components...")
                 onboard_control_components(
                     client,
                     certs,

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -102,17 +102,21 @@ def run(
         transient=True,
     ) as progress:
         task = progress.add_task("Connecting to CML...")
+        log.info("[1/11] Connecting to CML at %s...", cml_host)
         cml = connect_cml(cml_host, cml_user, cml_password)
 
         progress.update(task, description="Checking SD-WAN images...")
+        log.info("[2/11] Checking SD-WAN images for version %s...", version)
         images = _check_images(cml, version)
 
         try:
             if retry:
                 progress.update(task, description="Locating existing lab...")
+                log.info("[3/11] Locating existing lab...")
                 _find_lab(cml, manager_ip, manager_port)
             else:
                 progress.update(task, description=f"Creating lab {lab_name}...")
+                log.info("[3/11] Creating lab '%s' and booting control plane...", lab_name)
                 _create_lab(
                     cml,
                     lab_name=lab_name,
@@ -132,6 +136,10 @@ def run(
                 )
 
             progress.update(task, description="Waiting for SD-WAN Manager...")
+            log.info(
+                "[4/11] Waiting for SD-WAN Manager to come online "
+                "(this can take several minutes)..."
+            )
             client = wait_for_manager(
                 manager_ip,
                 manager_port,
@@ -142,12 +150,14 @@ def run(
             )
             try:
                 progress.update(task, description="Configuring SD-WAN Manager...")
+                log.info("[5/11] Configuring SD-WAN Manager (org, certificates, PKI=%s)...", pki)
                 configure_manager(
                     client, version, org_name, certs.chain, pki=pki,
                     on_status=lambda msg: progress.update(task, description=msg),
                     proxy_ip=proxy_ip, proxy_port=proxy_port, no_proxy=no_proxy,
                 )
 
+                log.info("[6/11] Onboarding control components (validator, controller)...")
                 onboard_control_components(
                     client,
                     certs,
@@ -159,18 +169,23 @@ def run(
                 )
 
                 progress.update(task, description="Uploading serial file...")
+                log.info("[7/11] Uploading serial file...")
                 client.upload_serial_file(serial_file)
 
                 progress.update(task, description="Importing basic configuration...")
+                log.info("[8/11] Importing basic configuration...")
                 _restore_basic_configuration(client, ip_type)
 
                 progress.update(task, description="Importing controller templates...")
+                log.info("[9/11] Importing controller templates...")
                 template_id = _import_controller_templates(client, ip_type)
 
                 progress.update(task, description="Attaching controller template...")
+                log.info("[10/11] Attaching controller template...")
                 _attach_controller_template(client, ip_type, template_id)
 
                 progress.update(task, description="Triggering network rediscovery...")
+                log.info("[11/11] Triggering network rediscovery...")
                 trigger_rediscovery(client)
             except ManagerAPIError as e:
                 log.error("%s", e)

--- a/src/catalyst_sdwan_lab/tasks/images.py
+++ b/src/catalyst_sdwan_lab/tasks/images.py
@@ -88,7 +88,7 @@ def upload(cml_host: str, cml_user: str, cml_password: str, images_dir: Path) ->
             for path, node_type, version in candidates:
                 norm_id = f"{node_type}-{version}"
                 if norm_id in existing:
-                    log.debug("%s: already exists, skipping", norm_id)
+                    log.info("Skipping %s (already exists)", norm_id)
                     console.print(f"  [dim]SKIPPED[/dim]  {norm_id} (already exists)")
                 else:
                     if node_defs is None:
@@ -96,7 +96,7 @@ def upload(cml_host: str, cml_user: str, cml_password: str, images_dir: Path) ->
                     if node_type not in node_defs:
                         log.error("Node definition '%s' not found. Run 'setup' first.", node_type)
                         raise typer.Exit(1)
-                    log.debug("Uploading %s as %s", path.name, norm_id)
+                    log.info("Starting upload of %s (%s)...", norm_id, path.name)
                     task = progress.add_task(f"Uploading {path.name}", total=path.stat().st_size)
                     upload_image_file(
                         cml._session,
@@ -111,6 +111,7 @@ def upload(cml_host: str, cml_user: str, cml_password: str, images_dir: Path) ->
                         "label": label,
                         "disk_image": path.name,
                     })
+                    log.info("Uploaded %s", norm_id)
                     console.print(f"  [green]UPLOADED[/green] {norm_id}")
         finally:
             cml.logout()

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -7,6 +7,7 @@ import os
 import re
 import tarfile
 import time
+import webbrowser
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -442,12 +443,22 @@ def _ensure_cisco_services(
     url = reg["verification_uri_complete"]
     expires_in = reg.get("expires_in", 600)
 
+    log.info(
+        "ACTION REQUIRED: Open this URL in your browser to register the Cisco account: %s "
+        "(expires in %ss)",
+        url, expires_in,
+    )
+    try:
+        if webbrowser.open(url):
+            log.info("Opened the registration URL in your default browser.")
+    except Exception as e:  # pragma: no cover - browser launch is best-effort
+        log.debug("Could not auto-open browser: %s", e)
     console.print(
         f"\nCisco account registration required. Open this URL in your browser:\n"
         f"  [bold cyan]{url}[/bold cyan]\n"
     )
     if on_status:
-        on_status("Waiting for Cisco account registration in browser...")
+        on_status(f"Waiting for Cisco account registration — open {url}")
 
     deadline = time.time() + expires_in
     while time.time() < deadline:

--- a/tests/test_mcp_adapter.py
+++ b/tests/test_mcp_adapter.py
@@ -1,0 +1,141 @@
+import asyncio
+import logging
+import time
+
+import pytest
+from typer import Exit
+
+pytest.importorskip("mcp", reason="requires the optional 'mcp' extra")
+
+from catalyst_sdwan_lab._mcp_adapter import (
+    _finalize_result,
+    capture_task,
+    poll_job,
+    start_job,
+)
+
+log = logging.getLogger("catalyst_sdwan_lab.tasks.test")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestFinalizeResult:
+    def test_success_returns_console_output(self) -> None:
+        assert _finalize_result("all good", None) == ("done", "all good")
+
+    def test_success_empty_output_defaults_to_done(self) -> None:
+        assert _finalize_result("", None) == ("done", "Done.")
+
+    def test_exit_zero_is_done(self) -> None:
+        status, text = _finalize_result("finished", Exit(0))
+        assert status == "done"
+        assert text == "finished"
+
+    def test_exit_nonzero_is_error(self) -> None:
+        status, text = _finalize_result("boom", Exit(1))
+        assert status == "error"
+        assert text == "Error: boom"
+
+    def test_exit_uses_exit_code_attribute(self) -> None:
+        # Regression: typer.Exit exposes .exit_code, not .code
+        status, text = _finalize_result("", Exit(2))
+        assert status == "error"
+        assert "code 2" in text
+
+    def test_generic_exception_is_error_with_traceback(self) -> None:
+        status, text = _finalize_result("", ValueError("nope"))
+        assert status == "error"
+        assert "ValueError" in text
+        assert "nope" in text
+
+
+class TestJobModel:
+    def test_job_streams_events_then_result(self) -> None:
+        def task() -> None:
+            log.info("first event")
+            log.info("second event")
+
+        job_id = start_job("test", task)
+        # Drain until done.
+        seen = ""
+        for _ in range(50):
+            out = _run(poll_job(job_id, timeout=1.0))
+            seen += out
+            if "status: done" in out:
+                break
+        assert "first event" in seen
+        assert "second event" in seen
+        assert "status: done" in seen
+
+    def test_events_are_delivered_once(self) -> None:
+        def task() -> None:
+            log.info("only once")
+            time.sleep(0.3)
+
+        job_id = start_job("test", task)
+        first = _run(poll_job(job_id, timeout=1.0))
+        assert "only once" in first
+        # Subsequent polls must not re-deliver the same event.
+        rest = ""
+        for _ in range(20):
+            out = _run(poll_job(job_id, timeout=1.0))
+            rest += out
+            if "status: done" in out:
+                break
+        assert "only once" not in rest
+
+    def test_failing_task_reports_error_status(self) -> None:
+        def task() -> None:
+            raise Exit(1)
+
+        job_id = start_job("test", task)
+        seen = ""
+        for _ in range(50):
+            out = _run(poll_job(job_id, timeout=1.0))
+            seen += out
+            if "status: error" in out or "status: done" in out:
+                break
+        assert "status: error" in seen
+
+    def test_unknown_job_id(self) -> None:
+        out = _run(poll_job("does-not-exist", timeout=0.1))
+        assert "unknown" in out
+
+    def test_completed_job_is_removed_after_result_delivered(self) -> None:
+        def task() -> None:
+            log.info("done event")
+
+        job_id = start_job("test", task)
+        for _ in range(50):
+            out = _run(poll_job(job_id, timeout=1.0))
+            if "status: done" in out:
+                break
+        # Job has been popped; polling again reports unknown.
+        out = _run(poll_job(job_id, timeout=0.1))
+        assert "unknown" in out
+
+
+class TestCaptureTask:
+    def test_returns_console_and_log_output(self) -> None:
+        def task() -> None:
+            log.info("hello from task")
+
+        result = capture_task(task)
+        assert "hello from task" in result
+
+    def test_exit_nonzero_returns_error(self) -> None:
+        def task() -> None:
+            raise Exit(1)
+
+        result = capture_task(task)
+        assert result.startswith("Error:")
+
+    def test_generic_exception_returns_error(self) -> None:
+        def task() -> None:
+            raise RuntimeError("kaboom")
+
+        result = capture_task(task)
+        assert "RuntimeError" in result
+        assert "kaboom" in result

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,153 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("mcp", reason="requires the optional 'mcp' extra")
+
+from catalyst_sdwan_lab import mcp_server
+from catalyst_sdwan_lab.mcp_server import _cml_creds, _started
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestCmlCreds:
+    def test_explicit_args_take_precedence(self) -> None:
+        host, user, pw = _cml_creds("h", "u", "p")
+        assert (host, user, pw) == ("h", "u", "p")
+
+    def test_falls_back_to_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CML_IP", "envhost")
+        monkeypatch.setenv("CML_USER", "envuser")
+        monkeypatch.setenv("CML_PASSWORD", "envpass")
+        host, user, pw = _cml_creds()
+        assert (host, user, pw) == ("envhost", "envuser", "envpass")
+
+    def test_missing_host_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CML_IP", raising=False)
+        with pytest.raises(ValueError, match="CML host"):
+            _cml_creds(None, "u", "p")
+
+    def test_missing_user_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CML_USER", raising=False)
+        with pytest.raises(ValueError, match="CML user"):
+            _cml_creds("h", None, "p")
+
+    def test_missing_password_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CML_PASSWORD", raising=False)
+        with pytest.raises(ValueError, match="CML password"):
+            _cml_creds("h", "u", None)
+
+
+class TestStartedMessage:
+    def test_contains_job_id_and_poll_instruction(self) -> None:
+        msg = _started("deploy", "abc123")
+        assert "abc123" in msg
+        assert "job_status" in msg
+        assert "deploy" in msg
+
+
+def _creds_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CML_IP", "cml")
+    monkeypatch.setenv("CML_USER", "admin")
+    monkeypatch.setenv("CML_PASSWORD", "secret")
+
+
+class TestDeployValidation:
+    def test_patty_mode_rejects_direct_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job") as start:
+            result = _run(
+                mcp_server.deploy(
+                    ctx=None,
+                    version="20.15.1",
+                    manager_password="pw",
+                    lab_name="lab",
+                    manager_port=4443,
+                    manager_ip="10.0.0.1",
+                )
+            )
+        assert result.startswith("Error:")
+        start.assert_not_called()
+
+    def test_direct_mode_requires_all_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job") as start:
+            result = _run(
+                mcp_server.deploy(
+                    ctx=None,
+                    version="20.15.1",
+                    manager_password="pw",
+                    lab_name="lab",
+                    manager_ip="10.0.0.1",  # missing mask + gateway
+                )
+            )
+        assert result.startswith("Error:")
+        start.assert_not_called()
+
+    def test_patty_mode_starts_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job", return_value="job1") as start:
+            result = _run(
+                mcp_server.deploy(
+                    ctx=None,
+                    version="20.15.1",
+                    manager_password="pw",
+                    lab_name="lab",
+                    manager_port=4443,
+                )
+            )
+        assert "job1" in result
+        start.assert_called_once()
+
+
+class TestAddDevicesValidation:
+    def test_unknown_device_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job") as start:
+            result = _run(
+                mcp_server.add_devices(
+                    ctx=None,
+                    count=1,
+                    device_type="router",
+                    version="20.15.1",
+                    lab_name="lab",
+                    manager_password="pw",
+                )
+            )
+        assert result.startswith("Error:")
+        start.assert_not_called()
+
+    def test_zero_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job") as start:
+            result = _run(
+                mcp_server.add_devices(
+                    ctx=None,
+                    count=0,
+                    device_type="edge",
+                    version="20.15.1",
+                    lab_name="lab",
+                    manager_password="pw",
+                )
+            )
+        assert result.startswith("Error:")
+        start.assert_not_called()
+
+    def test_edge_starts_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _creds_env(monkeypatch)
+        with patch.object(mcp_server, "start_job", return_value="jobE") as start:
+            result = _run(
+                mcp_server.add_devices(
+                    ctx=None,
+                    count=2,
+                    device_type="edges",  # plural accepted
+                    version="20.15.1",
+                    lab_name="lab",
+                    manager_password="pw",
+                )
+            )
+        assert "jobE" in result
+        start.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -35,6 +38,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -123,8 +135,14 @@ dependencies = [
     { name = "virl2-client" },
 ]
 
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp", extra = ["cli"] },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "mcp", extra = ["cli"] },
     { name = "pytest" },
     { name = "ruff" },
     { name = "websocket-client" },
@@ -135,6 +153,7 @@ requires-dist = [
     { name = "cisco-sdwan", specifier = ">=1.28" },
     { name = "cryptography", specifier = ">=49.0.0" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "paramiko", specifier = ">=5.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.34.2" },
@@ -142,9 +161,11 @@ requires-dist = [
     { name = "typer", specifier = ">=0.26.7" },
     { name = "virl2-client", specifier = ">=2.8.0" },
 ]
+provides-extras = ["mcp"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mcp", extras = ["cli"], specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.18" },
     { name = "websocket-client", specifier = ">=1.9.0" },
@@ -333,6 +354,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +468,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.15"
 source = { registry = "https://pypi.org/simple" }
@@ -471,6 +513,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -557,6 +626,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -728,12 +828,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -785,6 +913,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
 ]
 
 [[package]]
@@ -843,6 +1011,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +1050,129 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/1f/a2dca5ffdbf1d475ffc4e80e4d5d720ff3a00f691795910116960ee12511/rpds_py-2026.6.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7b689145a1485c335569bd056464f3243a29af7ed3871c7be31ad624ba239bc7", size = 342174, upload-time = "2026-06-30T07:14:54.821Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/dc/323d08583c0832911768663d1944f0107fcd4088704858d84b5e06d105a0/rpds_py-2026.6.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:db08f45aecde626498fb3df07bcf6d2ec040af42e859a4f5040d79c200342911", size = 345513, upload-time = "2026-06-30T07:14:56.515Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2a/e31989834d18d2f26ec1d2774c5b1eb3331df4ea8ada525175294c94b48a/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:acc992ab27b15f852c76755eb2ab7dce86585ddadba6fa5946e58556088845b4", size = 373783, upload-time = "2026-06-30T07:14:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/87/fe/e80107ee3639585c9941c17d6a42cd65325022f656c023191fce78c324c8/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f88d653e7b3b779d71ae7454e20dcc9b6bae903f33c269db9f2be41bda3f261", size = 378316, upload-time = "2026-06-30T07:14:59.077Z" },
+    { url = "https://files.pythonhosted.org/packages/22/6f/81e3adf81acfb6fa694de2a6e4e7d8863121e3e0799e0a7725e6cf5679c4/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e52655eaf81e32593abedaa4bfe33170c8cfedf3365ed9be6e11e07f148f0278", size = 499423, upload-time = "2026-06-30T07:15:00.488Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/41263969df0ce3d9af2a96d5005a288200af1989aed3354bfceb5fc0b21f/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dfcc8b909769d19db55c7cc9541eb64b9b774b1057ffffb4f1048070475bb9f9", size = 386077, upload-time = "2026-06-30T07:15:01.911Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/19/7e98f468bd50346faff5b10e5297374b443bfdddacc8e9fbc65984539597/rpds_py-2026.6.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c1255b302953c86a486b81d330d5ee1d5bd937691ce271b6be0ef0e299eaab7", size = 371315, upload-time = "2026-06-30T07:15:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/99/3c/2b973b4d371906a134b03decfea7f5d9835a2c6d263454392e15b64b5b18/rpds_py-2026.6.3-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8d2294a31386bfa251d8c8a39472beee17db67d4f1a6eabea665d35c9a4461c3", size = 383502, upload-time = "2026-06-30T07:15:04.627Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2a/12e2799500af0a307bca76b63361c51f9fe479223561489c29eea1f2ee41/rpds_py-2026.6.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8f23ead891a3b762f35ab3b04623da7056545b48aa60d59957e6789914545da", size = 402673, upload-time = "2026-06-30T07:15:05.856Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e3/21e5872d165fe08be4f229e3d5ee9d90019c0bf0e5538de60dbd54009450/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:421aba32367055614287a4292b6a17f1939c9452299f7a0209c117e990b646d4", size = 549964, upload-time = "2026-06-30T07:15:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d0/5ee0fe36844297de8123bee27bc12078c1a7416ad9f1b8a8ca18d6b0c0ac/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:1e5822dfc2f0d4ab7e745eaa6d85945069329beeccef965af3f3bb26058fcab6", size = 615446, upload-time = "2026-06-30T07:15:08.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/1ea5873cb683f2fbe5f21b23ea1f6d179ead19f3c5b249b7eb5dca568ef2/rpds_py-2026.6.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:83e35b57523816c8613fd0776b40cd8bb9f596b37ddd2692eb4a6bb5ab2f8c93", size = 576975, upload-time = "2026-06-30T07:15:09.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e1/90ef639217a5ddb15b7f4f61b1c33911fd044ad03c311bafdd2bcab85582/rpds_py-2026.6.3-cp311-cp311-win32.whl", hash = "sha256:de3eceba0b683bcbb1ab93da016d0270df1f9ae7be716b40214c5dafac6ea45a", size = 204453, upload-time = "2026-06-30T07:15:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/b7/b7a1695d7af36f521fb11e80d6d3adbd744f73b921859bd3c2a2c0dc706f/rpds_py-2026.6.3-cp311-cp311-win_amd64.whl", hash = "sha256:2c54a076ca4d370980ab57bc0e31df57bbe8d41340436a90ef8b1219a3cbb127", size = 223219, upload-time = "2026-06-30T07:15:12.476Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a2/145afacf796e4506062825941176ad9445c2dcf2b3b6a1f13d3030a15e19/rpds_py-2026.6.3-cp311-cp311-win_arm64.whl", hash = "sha256:168c733a7112e071bb7a66460e667edfcff06c017a3c523f7a8a8e08d0140804", size = 219137, upload-time = "2026-06-30T07:15:13.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/f0d19ac587fd0e4ab6b72cda355e9c5a6166b01ef7e064e437aef8eb9fef/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:4cf2d36a2357e4d07bb5a4f98801265327b48256867816cfd2ceb001e9754a8f", size = 349791, upload-time = "2026-06-30T07:17:33.315Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c7/1d49d204c9fd2ee6c537601dc4c1ba921e03363ca576bfab94a00254ac9a/rpds_py-2026.6.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:30c6dc199b24a5e3e81d50da0f00858c5bbdb2617a750395687f4339c5818171", size = 352842, upload-time = "2026-06-30T07:17:34.897Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/e5/c0b5dc93cd0d4c06ce1f438907649514e2ea077bcd911e3154a51e96c38e/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9891e594296ab9dada6551c8e7b387b2721f27a67eecd528412e8906247a7b90", size = 382094, upload-time = "2026-06-30T07:17:36.514Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/54/ec0e907b4ca8d541112db352409bd15f871c9b243e0c92c9b5a46ae96f01/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5c2dc92304aa48a4a60443b548bb12f12e119d4b72f314015e67b9e1be97fca", size = 388662, upload-time = "2026-06-30T07:17:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f4/921c22a4fd0f1c1ac13a3996ffbf0aa67951e2c8ad0d1d9574938a2932e8/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:127e08c0642d880cf32ca47ec2a4a77b901f7e2dd1ad9762adb13955d72ffcc9", size = 504896, upload-time = "2026-06-30T07:17:39.689Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/1b/a114b972cefa1ab1cdb3c7bb177cd3844a12826c507c722d3a73516dbbaf/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8bb68f03f395eb793220b45c097bd4d8c32944393da0fad8b999efac0868fc8c", size = 391545, upload-time = "2026-06-30T07:17:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/98/af9b3db77d47fcbe6c8c1f36e2c2147ec70292819e99c325f871584a1c11/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3450b693fde92133e9f51060568a4c31fcca76d5e53bbd611e689ca446517e9", size = 380059, upload-time = "2026-06-30T07:17:42.857Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ba/0efd8668b97c1d26a61566386c636a7a7a09829e474fdf807caa15a2c844/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:5e8d07bddee435a2ff6f1920e18feff28d0bc4533e42f4bf6927fbd073312c41", size = 393235, upload-time = "2026-06-30T07:17:44.637Z" },
+    { url = "https://files.pythonhosted.org/packages/62/90/8c139ee9690f73b0829f32647de6f40d826f8f443af6fa72644f96351aac/rpds_py-2026.6.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3a83ae6c67b7676b9878378547ca8e93ed77a580037bcbcd1d32f739e1e6089c", size = 413008, upload-time = "2026-06-30T07:17:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/0043896fdd7828ce09a1d9a8b06433714d0960fc4ff3fc4aa72b666b764e/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2bfd04c19ddbd6640de0b51894d764bd2758854d5b75bd102d2ef10cb9c293a9", size = 558118, upload-time = "2026-06-30T07:17:47.759Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/02355f0e134f783a8f9814c4680a1bd311d37671577a5964ea838573ff37/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:ca6546b66be9dc4738b1b043d5ebd5488c66c578c5ff0fd0e8065313fe3afb76", size = 623138, upload-time = "2026-06-30T07:17:49.355Z" },
+    { url = "https://files.pythonhosted.org/packages/10/85/48f0abdcef5cce4e034c7a5b0ceeceba0b01bf0d942824f4bb720afe2dec/rpds_py-2026.6.3-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:8e65860d238379ed982fd9ba690579b5e95af2f4840f99c772816dbe573cb826", size = 586486, upload-time = "2026-06-30T07:17:51.141Z" },
 ]
 
 [[package]]
@@ -902,6 +1207,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296", size = 16518, upload-time = "2026-06-20T17:36:56.729Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]
@@ -947,6 +1278,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Two related, fully-additive changes (one commit each):

1. **Stream task progress via log events** — emit structured `log.info` at each
   step of the long-running tasks (deploy/add/images), plus surface the Cisco PKI
   registration URL and auto-open it in the browser.
2. **Add an optional MCP server** — expose the existing tasks as Model Context
   Protocol tools so an LLM agent (VS Code Copilot, opencode, …) can drive labs
   conversationally, via a new `csdwan-mcp` entry point.

(As discussed/demoed earlier — opening the PR now.)

## Why background jobs
An MCP tool's only channel back to the agent is its return value, delivered once
on completion. A 15-minute `deploy` as a single blocking call gives the agent zero
visibility and can't surface interactive prompts. So the long tools (deploy,
restore, add_devices, images_upload) run as **background jobs**: the tool returns a
`job_id` immediately and the agent pulls progress via a `job_status` tool that
long-polls for new log events + the final result. This also cleanly handles
**Cisco PKI**: the registration URL is emitted as an `ACTION REQUIRED` event the
agent relays to the user; the job keeps polling the token and resumes automatically
once the user registers — no special-casing.

## What changed
- `tasks/deploy.py`, `tasks/add.py`, `tasks/images.py`, `tasks/utils.py`: progress
  log markers + Cisco PKI URL logging/browser-open
- `mcp_server.py` (new): FastMCP server — setup, deploy, add_devices, delete_lab,
  backup_lab, restore_lab, images_list/upload/delete, sign_csr, job_status
- `_mcp_adapter.py` (new): sync→async bridge, output capture, background-job model
- `pyproject.toml`: `mcp[cli]` as an **optional extra** (`pip install …[mcp]`);
  added to the dev group for tests
- `tests/`: unit coverage for the job model, result finalization, credential
  resolution, and tool validation (skip cleanly without the extra)

## Testing
- `uv run pytest` — all green (incl. the new tests)
- Verified end-to-end on live CML: enterprise deploy, Cisco-PKI deploy (interactive
  registration), and adding 3 edge devices — all driven through the MCP
  `job_status` polling loop

The CLI is unchanged; everything here is optional and additive.