### PR TITLE
add support for manager clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
-# Catalyst SD-WAN Lab 3.0.2 [unreleased]
+# Catalyst SD-WAN Lab 3.1.0 [unreleased]
 
 - Fix backup task failing to extract config from SD-WAN and SD-Routing edges when `#` present in interface description
+- Add Manager clustering support via `csdwan add managers <version>`
+  - Deploys additional Manager nodes into the CML topology with a dedicated Cluster switch
+  - Configures cluster IP on the primary Manager and enrolls new nodes one-by-one
+  - Supports `--persona` flag (`compute-and-data` default, `compute`, `data`)
+  - Certificates signed automatically after each node reaches Ready state (enterprise and Cisco PKI)
+- Update `backup` to capture cluster node personas from the live cluster management API and embed them in each Manager's backed-up cloud-init
+- Update `restore` to re-enroll secondary Manager nodes into the cluster after Sastre restore
 
 # Catalyst SD-WAN Lab 3.0.1 [Jun 24, 2026]
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ csdwan add [OPTIONS] <count> <device-type> <version>
 | Argument | Description |
 |---|---|
 | `count` | Number of devices to add |
-| `device-type` | `controller(s)`, `validator(s)`, `edge(s)`, `sdrouting` |
+| `device-type` | `manager(s)`, `controller(s)`, `validator(s)`, `edge(s)`, `sdrouting` |
 | `version` | SD-WAN software version |
 
 **Options:**
@@ -220,17 +220,22 @@ csdwan add [OPTIONS] <count> <device-type> <version>
 | `--lab` | `LAB_NAME` | CML lab name |
 | `--manager-user` | `MANAGER_USER` | Manager username (default: `admin`) |
 | `--manager-pass` | `MANAGER_PASSWORD` | Manager password |
+| `--persona` | | Manager cluster persona: `compute-and-data` (default), `compute`, `data` — only for `manager(s)` |
 | `--cpus` | | Override CPU count for each added node |
 | `--ram` | | Override RAM in MB for each added node |
 
 **Examples:**
 
 ```sh
+csdwan add 2 managers 20.15.1
+csdwan add 2 managers 20.15.1 --persona data
 csdwan add 1 validator 20.15.1
 csdwan add 2 controllers 20.15.1
 csdwan add 3 edges 20.15.1
 csdwan add 2 sdrouting 17.15.1
 ```
+
+Adding managers deploys additional Manager nodes, sets up the cluster interface, enrolls them into the existing Manager cluster, and signs their certificates. The cluster switch is created automatically in the CML topology.
 
 ---
 
@@ -241,6 +246,7 @@ Backs up a running SD-WAN lab to a zip archive (or directory). Captures:
 - CML topology with running configs extracted via SSH from all nodes
 - SD-WAN Manager configuration (templates, config groups, policies, feature profiles) via Sastre
 - Network hierarchy (MRF regions)
+- Cluster configuration including node personas
 
 The lab must be running. Configs are extracted live over SSH — shut-down nodes are skipped with a warning.
 

--- a/src/catalyst_sdwan_lab/cli.py
+++ b/src/catalyst_sdwan_lab/cli.py
@@ -320,7 +320,10 @@ class ManagerPersona(str, Enum):
 def add(
     count: Annotated[int, typer.Argument(help="Number of devices to add")],
     device_type: Annotated[
-        str, typer.Argument(help="Device type: controller(s), validator(s), edge(s), sdrouting, manager(s)")
+        str,
+        typer.Argument(
+            help="Device type: manager(s), controller(s), validator(s), edge(s), sdrouting"
+        ),
     ],
     version: Annotated[str, typer.Argument(help="SD-WAN software version (e.g. 20.15.1)")],
     lab_name: Annotated[
@@ -355,7 +358,8 @@ def add(
     device = _DEVICE_TYPES.get(device_type.lower())
     if device is None:
         log.error(
-            "Unknown device type '%s'. Valid: controller, validator, edge, sdrouting, manager.", device_type
+            "Unknown device type '%s'. Valid: manager, controller, validator, edge, sdrouting.",
+                device_type,
         )
         raise typer.Exit(1)
     if device in ("controller", "validator"):

--- a/src/catalyst_sdwan_lab/cli.py
+++ b/src/catalyst_sdwan_lab/cli.py
@@ -1,6 +1,7 @@
 import ipaddress
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Annotated, Optional
 
@@ -294,6 +295,8 @@ def sign(
 
 
 _DEVICE_TYPES: dict[str, str] = {
+    "manager": "manager",
+    "managers": "manager",
     "controller": "controller",
     "controllers": "controller",
     "validator": "validator",
@@ -304,11 +307,20 @@ _DEVICE_TYPES: dict[str, str] = {
 }
 
 
+class ManagerPersona(str, Enum):
+    compute_and_data = "compute-and-data"
+    compute = "compute"
+    data = "data"
+
+    def to_api_value(self) -> str:
+        return self.value.upper().replace("-", "_")
+
+
 @app.command()
 def add(
     count: Annotated[int, typer.Argument(help="Number of devices to add")],
     device_type: Annotated[
-        str, typer.Argument(help="Device type: controller(s), validator(s), edge(s), sdrouting")
+        str, typer.Argument(help="Device type: controller(s), validator(s), edge(s), sdrouting, manager(s)")
     ],
     version: Annotated[str, typer.Argument(help="SD-WAN software version (e.g. 20.15.1)")],
     lab_name: Annotated[
@@ -325,6 +337,10 @@ def add(
             hide_input=True, prompt="Manager password"
         ),
     ] = ...,  # type: ignore[assignment]
+    persona: Annotated[
+        ManagerPersona,
+        typer.Option("--persona", help="Manager persona (only for manager(s) device type)"),
+    ] = ManagerPersona.compute_and_data,
     cpus: Annotated[
         Optional[int], typer.Option("--cpus", help="Override number of CPUs for each node")
     ] = None,
@@ -339,7 +355,7 @@ def add(
     device = _DEVICE_TYPES.get(device_type.lower())
     if device is None:
         log.error(
-            "Unknown device type '%s'. Valid: controller, validator, edge, sdrouting.", device_type
+            "Unknown device type '%s'. Valid: controller, validator, edge, sdrouting, manager.", device_type
         )
         raise typer.Exit(1)
     if device in ("controller", "validator"):
@@ -373,6 +389,18 @@ def add(
             manager_user=manager_user,
             manager_password=manager_pass,
             count=count,
+            cpus=cpus,
+            ram=ram,
+        )
+    elif device == "manager":
+        _add.run_managers(
+            *_cml_credentials(),
+            lab_name=lab_name,
+            version=version,
+            manager_user=manager_user,
+            manager_password=manager_pass,
+            count=count,
+            persona=persona.to_api_value(),
             cpus=cpus,
             ram=ram,
         )

--- a/src/catalyst_sdwan_lab/data/cml_lab_definition/backup/cat-sdwan-manager.j2
+++ b/src/catalyst_sdwan_lab/data/cml_lab_definition/backup/cat-sdwan-manager.j2
@@ -16,7 +16,13 @@ write_files:
 {% filter indent(width=4, first=True) %}
 {{ root_ca }}
 {% endfilter %}
-
+{% if persona != 'COMPUTE_AND_DATA' %}
+- path: /opt/web-app/etc/persona
+  owner: vmanage:vmanage-admin
+  permissions: '0644'
+  content: |
+    {"persona":"{{ persona }}"}
+{% endif %}
 - path: /etc/confd/init/zcloud.xml
   content: |
 {% filter indent(width=4, first=True) %}

--- a/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
+++ b/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
@@ -8,6 +8,13 @@ mounts:
 write_files:
 - path: /etc/default/personality
   content: "vmanage\n"
+{% if persona != 'COMPUTE_AND_DATA' %}
+- path: /opt/web-app/etc/persona
+  owner: vmanage:vmanage-admin
+  permissions: '0644'
+  content: |
+    {"persona":"{{ persona }}"}
+{% endif %}
 - path: /etc/default/inited
   content: "1\n"
 - path: /usr/share/viptela/symantec-root-ca.crt
@@ -106,6 +113,13 @@ write_files:
                 <netconf>true</netconf>
               </allow-service>
             </tunnel-interface>
+            <shutdown>false</shutdown>
+          </interface>
+          <interface>
+            <if-name>eth2</if-name>
+            <ip>
+              <address>172.16.254.{{ manager_num }}/24</address>
+            </ip>
             <shutdown>false</shutdown>
           </interface>
         </vpn-instance>

--- a/src/catalyst_sdwan_lab/manager_client.py
+++ b/src/catalyst_sdwan_lab/manager_client.py
@@ -330,7 +330,9 @@ class ManagerClient:
                 time.sleep(interval)
                 continue
             raise ManagerAPIError(f"HTTP {response.status_code}: {response.text[:200]}")
-        raise ManagerAPIError(f"Cluster node {cluster_ip} did not become reachable after {retries * interval}s.")
+        raise ManagerAPIError(
+            f"Cluster node {cluster_ip} did not become reachable after {retries * interval}s."
+        )
 
     def rediscover_devices(self, devices: list[dict[str, Any]]) -> None:
         self._post(
@@ -345,7 +347,9 @@ class ManagerClient:
              "generateCSR": False, "personality": personality},
         )
 
-    def update_device_connection(self, uuid: str, device_ip: str, username: str, password: str) -> None:
+    def update_device_connection(
+        self, uuid: str, device_ip: str, username: str, password: str
+    ) -> None:
         self._put(
             f"/dataservice/system/device/{uuid}",
             {"deviceIP": device_ip, "username": username, "password": password},

--- a/src/catalyst_sdwan_lab/manager_client.py
+++ b/src/catalyst_sdwan_lab/manager_client.py
@@ -264,6 +264,74 @@ class ManagerClient:
     def get_sync_status(self) -> list[dict[str, Any]]:
         return self._get("/dataservice/device/sync_status?groupId=all").get("data", [])
 
+    def get_cluster_management_list(self) -> list[dict[str, Any]]:
+        return self._get("/dataservice/clusterManagement/list").get("data", [])
+
+    def get_local_system_ip(self) -> str:
+        return self._get("/dataservice/device/vmanage")["data"]["ipAddress"]
+
+    def get_vpn0_interface_ip(self, system_ip: str, ifname: str) -> str:
+        interfaces = self._get(
+            f"/dataservice/device/interface?vpn-id=0&deviceId={system_ip}"
+        ).get("data", [])
+        iface = next(
+            (i for i in interfaces if i.get("ifname") == ifname and i.get("af-type") == "ipv4"),
+            None,
+        )
+        if iface is None:
+            raise ManagerAPIError(f"Interface {ifname} not found in VPN 0 on {system_ip}")
+        return iface["ip-address"].split("/")[0]
+
+    def setup_cluster_ip(
+        self, cluster_ip: str, persona: str, username: str, password: str
+    ) -> None:
+        try:
+            self._put(
+                "/dataservice/clusterManagement/setup/",
+                {
+                    "persona": persona,
+                    "deviceIP": cluster_ip,
+                    "username": username,
+                    "password": password,
+                    "genCSR": False,
+                    "services": {"sd-avc": {"server": True}},
+                    "vmanageID": "0",
+                },
+            )
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            # NMS API restarts after cluster IP setup — connection drop/timeout is expected
+            pass
+
+    def add_cluster_node(
+        self, cluster_ip: str, persona: str, username: str, password: str,
+        retries: int = 120, interval: int = 30,
+    ) -> None:
+        """Blocks until the POST succeeds (200 OK), retrying on VCC0001 (node API not yet ready)."""
+        for _ in range(retries):
+            response = self._session.post(
+                f"{self._base}/dataservice/clusterManagement/setup/",
+                json={
+                    "persona": persona,
+                    "deviceIP": cluster_ip,
+                    "username": username,
+                    "password": password,
+                    "genCSR": False,
+                    "services": {"sd-avc": {"server": False}},
+                },
+                timeout=self._TIMEOUT,
+            )
+            if response.ok:
+                return
+            try:
+                code = response.json().get("error", {}).get("code", "")
+            except Exception:
+                code = ""
+            if response.status_code == 400 and code == "VCC0001":
+                time.sleep(interval)
+                continue
+            raise ManagerAPIError(f"HTTP {response.status_code}: {response.text[:200]}")
+        raise ManagerAPIError(f"Cluster node {cluster_ip} did not become reachable after {retries * interval}s.")
+
     def rediscover_devices(self, devices: list[dict[str, Any]]) -> None:
         self._post(
             "/dataservice/device/action/rediscover",
@@ -275,6 +343,12 @@ class ManagerClient:
             "/dataservice/system/device",
             {"deviceIP": ip, "username": username, "password": password,
              "generateCSR": False, "personality": personality},
+        )
+
+    def update_device_connection(self, uuid: str, device_ip: str, username: str, password: str) -> None:
+        self._put(
+            f"/dataservice/system/device/{uuid}",
+            {"deviceIP": device_ip, "username": username, "password": password},
         )
 
     def generate_csr(self, ip: str) -> tuple[str, str]:
@@ -318,6 +392,8 @@ class ManagerClient:
     def logout(self) -> None:
         try:
             self._session.get(f"{self._base}/logout", timeout=self._TIMEOUT)
+        except requests.exceptions.RequestException:
+            pass
         finally:
             self._session.close()
 

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -1,6 +1,8 @@
+import datetime
 import logging
 import re
 import time
+
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal
 
@@ -8,6 +10,7 @@ import typer
 from jinja2 import Environment, FileSystemLoader
 from rich.markup import escape
 from rich.progress import Progress, SpinnerColumn, TextColumn
+from virl2_client import ClientLibrary
 from virl2_client.exceptions import InterfaceNotFound
 from virl2_client.models.interface import Interface
 from virl2_client.models.lab import Lab
@@ -33,12 +36,16 @@ from .utils import (
     connect_manager,
     console,
     detect_ip_type,
+    enroll_cluster_manager,
+    ensure_cluster_ip_configured,
     find_lab,
     load_certs,
     resolve_image,
+    sha512_crypt,
     sign_device_cert,
     trigger_rediscovery,
     wait_for_edges_onboarded,
+    wait_for_manager,
 )
 
 log = logging.getLogger(__name__)
@@ -694,4 +701,205 @@ def _get_config_group_id(client: ManagerClient, name: str) -> str:
         log.error("Config group '%s' not found in Manager.", name)
         raise typer.Exit(1)
     return cg["id"]
+
+
+def run_managers(
+    cml_host: str,
+    cml_user: str,
+    cml_password: str,
+    lab_name: str,
+    version: str,
+    manager_user: str,
+    manager_password: str,
+    count: int,
+    persona: str,
+    cpus: int | None = None,
+    ram: int | None = None,
+) -> None:
+    cml = connect_cml(cml_host, cml_user, cml_password)
+    lab, manager_host, manager_port = find_lab(cml, lab_name)
+
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
+                  transient=True, console=console) as progress:
+        task = progress.add_task("Setting up Cluster switch...")
+        cluster = _ensure_cluster_switch(lab)
+        progress.update(task, description="Connecting existing managers to Cluster switch...")
+        _connect_managers_to_cluster(lab, cluster)
+
+        progress.update(task, description="Checking cluster IP configuration...")
+        client = connect_manager(manager_host, manager_port, manager_user, manager_password)
+        try:
+            org_name = client.get_organization() or ""
+            ip_type = detect_ip_type(lab)
+            pki = client.get_certificate_signing()
+            ensure_cluster_ip_configured(
+                client, manager_user, manager_password, persona=persona,
+                on_status=lambda s: progress.update(task, description=s),
+            )
+        except ManagerAPIError as e:
+            log.error("%s", e)
+            raise typer.Exit(1)
+        finally:
+            client.logout()
+
+        progress.update(task, description=f"Adding {count} manager node(s) to CML...")
+        new_nodes = _create_manager_nodes(
+            lab, cluster, cml, count, version,
+            manager_user, manager_password, org_name, ip_type, persona, cpus, ram,
+        )
+
+        progress.update(task, description="Waiting for managers to boot...")
+        for node, _ in new_nodes:
+            node.wait_until_converged()
+
+        progress.update(task, description="Waiting for primary Manager...")
+        client = wait_for_manager(
+            manager_host, manager_port, manager_user, manager_password, version,
+        )
+        certs = load_certs()
+        try:
+            for node, cluster_ip in new_nodes:
+                progress.update(task, description=f"Adding {node.label} to cluster...")
+                client = enroll_cluster_manager(
+                    client, cluster_ip, persona,
+                    manager_host, manager_port, manager_user, manager_password, version,
+                    certs, pki, node.label,
+                    on_status=lambda s: progress.update(task, description=s),
+                )
+        except ManagerAPIError as e:
+            log.error("%s", e)
+            raise typer.Exit(1)
+        finally:
+            client.logout()
+
+    label = new_nodes[0][0].label if count == 1 else f"{count} managers"
+    console.print(f"[green]Added.[/green] {label} added to lab '{escape(lab_name)}'.")
+
+def _create_manager_nodes(
+    lab: Lab,
+    cluster: Node,
+    cml: ClientLibrary,
+    count: int,
+    version: str,
+    manager_user: str,
+    manager_password: str,
+    org_name: str,
+    ip_type: str,
+    persona: str,
+    cpus: int | None,
+    ram: int | None,
+) -> list[tuple[Node, str]]:
+    image_id = resolve_image(cml, "cat-sdwan-manager", version)
+    certs = load_certs()
+    encrypted_password = sha512_crypt(manager_password)
+    now = (
+        datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3]
+        + "+00:00"
+    )
+    vpn0 = next(
+        (n for n in lab.nodes() if n.label == "VPN0" and n.node_definition == "unmanaged_switch"),
+        None,
+    )
+    if vpn0 is None:
+        log.error("VPN0 switch not found in lab.")
+        raise typer.Exit(1)
+
+    template = _CLOUD_INIT_ENV.get_template("manager-cloud-init.j2")
+    existing_managers = [n for n in lab.nodes() if n.node_definition == "cat-sdwan-manager"]
+    base_num = len(existing_managers)
+    ref = min(existing_managers, key=lambda n: n.y, default=None)
+    base_x = ref.x if ref else -280
+    base_y = (ref.y if ref else -80) - 80
+    nodes: list[tuple[Node, str]] = []
+
+    for i in range(count):
+        manager_num = str(base_num + i + 1)
+        config = template.render(
+            root_ca=certs.chain,
+            org_name=org_name,
+            validator_fqdn=VALIDATOR_FQDN,
+            manager_num=manager_num,
+            manager_user=manager_user,
+            manager_pass=encrypted_password,
+            manager_external_ip="",
+            external_subnet_mask="",
+            external_gateway="",
+            ip_type=ip_type,
+            patty_used=True,
+            persona=persona,
+            password_change_time=now,
+        )
+        node = lab.create_node(
+            label=f"Manager0{manager_num}",
+            node_definition="cat-sdwan-manager",
+            image_definition=image_id,
+            configuration=config,
+            x=base_x,
+            y=base_y - 80 * i,
+            populate_interfaces=True,
+            wait=False,
+            cpus=cpus,
+            ram=ram,
+        )
+        eth1 = _sync_until_interface(lab, node, "eth1")
+        free_vpn0 = vpn0.next_available_interface()
+        if free_vpn0 is None:
+            log.error("VPN0 switch has no free ports.")
+            raise typer.Exit(1)
+        lab.create_link(eth1, free_vpn0)
+
+        eth2 = node.get_interface_by_label("eth2")
+        free_cluster = cluster.next_available_interface()
+        if free_cluster is None:
+            log.error("Cluster switch has no free ports.")
+            raise typer.Exit(1)
+        lab.create_link(eth2, free_cluster)
+        nodes.append((node, f"172.16.254.{manager_num}"))
+
+    for node, _ in nodes:
+        node.start()
+        log.info("Started manager %s.", node.label)
+
+    return nodes
+
+
+def _ensure_cluster_switch(lab: Lab) -> Node:
+    existing = next(
+        (n for n in lab.nodes() if n.label == "Cluster" and n.node_definition == "unmanaged_switch"),
+        None,
+    )
+    if existing is not None:
+        if not existing.is_active():
+            existing.start()
+            existing.wait_until_converged()
+            log.info("Started stopped Cluster switch.")
+        return existing
+    node = lab.create_node(
+        label="Cluster",
+        node_definition="unmanaged_switch",
+        x=-400,
+        y=-160,
+        populate_interfaces=True,
+        wait=True,
+    )
+    node.start()
+    node.wait_until_converged()
+    log.info("Created Cluster switch.")
+    return node
+
+
+def _connect_managers_to_cluster(lab: Lab, cluster: Node) -> None:
+    managers = [n for n in lab.nodes() if n.node_definition == "cat-sdwan-manager"]
+    for manager in managers:
+        eth2 = manager.get_interface_by_label("eth2")
+        if eth2.connected:
+            log.info("%s eth2 already connected, skipping.", manager.label)
+            continue
+        free = cluster.next_available_interface()
+        if free is None:
+            log.error("Cluster switch has no free ports.")
+            raise typer.Exit(1)
+        lab.create_link(eth2, free)
+        eth2.bring_up()
+        log.info("Linked %s eth2 to Cluster switch.", manager.label)
 

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 import re
 import time
-
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal
 
@@ -865,7 +864,10 @@ def _create_manager_nodes(
 
 def _ensure_cluster_switch(lab: Lab) -> Node:
     existing = next(
-        (n for n in lab.nodes() if n.label == "Cluster" and n.node_definition == "unmanaged_switch"),
+        (
+            n for n in lab.nodes()
+            if n.label == "Cluster" and n.node_definition == "unmanaged_switch"
+        ),
         None,
     )
     if existing is not None:

--- a/src/catalyst_sdwan_lab/tasks/backup.py
+++ b/src/catalyst_sdwan_lab/tasks/backup.py
@@ -114,6 +114,14 @@ def run(
                 topology_str = lab.download()
                 topology: Any = yaml.safe_load(topology_str)
 
+                cluster_list = client.get_cluster_management_list()
+                cluster_personas: dict[str, str] = {
+                    n["configJson"]["host-name"]: n["configJson"].get("persona", "COMPUTE_AND_DATA")
+                    for entry in cluster_list
+                    for n in entry.get("data", [])
+                    if "configJson" in n and "host-name" in n["configJson"]
+                }
+
                 extract_nodes = [
                     n for n in nodes
                     if n.is_active() and (
@@ -142,8 +150,12 @@ def run(
                         except Exception as e:
                             log.error("Failed to extract config from %s: %s", node.label, e)
                             raise typer.Exit(1)
+                        hostname_m = re.search(r"<host-name>([^<]+)</host-name>", config_xml)
+                        persona = cluster_personas.get(
+                            hostname_m.group(1) if hostname_m else "", "COMPUTE_AND_DATA"
+                        )
                         cloud_init = _render_cloud_init(
-                            node_def, root_ca=certs.chain, config=config_xml
+                            node_def, root_ca=certs.chain, config=config_xml, persona=persona,
                         )
                         _update_node_configuration(topology, node.label, cloud_init)
                     elif node_def == "cat-sdwan-edge":

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -355,6 +355,7 @@ def _create_lab(
         manager_port=manager_port,
         patty_used=patty,
         password_change_time=now,
+        persona="COMPUTE_AND_DATA",
     )
 
     log.info("Importing lab '%s' to CML...", lab_name)

--- a/src/catalyst_sdwan_lab/tasks/restore.py
+++ b/src/catalyst_sdwan_lab/tasks/restore.py
@@ -348,7 +348,10 @@ def _patch_topology(
                     r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<address>)([\d./]+)(</address>)",
                     cfg,
                 ):
-                    cfg = cfg.replace(m.group(0), f"{m.group(1)}{manager_ip}{manager_mask}{m.group(3)}")
+                    cfg = cfg.replace(
+                        m.group(0),
+                        f"{m.group(1)}{manager_ip}{manager_mask}{m.group(3)}",
+                    )
                 if m := re.search(
                     r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<next-hop>[\s\S]+?<address>)([\d.]+)(</address>)",
                     cfg,

--- a/src/catalyst_sdwan_lab/tasks/restore.py
+++ b/src/catalyst_sdwan_lab/tasks/restore.py
@@ -5,7 +5,7 @@ import re
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 import typer
 import yaml
@@ -18,12 +18,15 @@ from catalyst_sdwan_lab.ssh_client import fix_sdrouting_default_route
 from .delete import run as _delete_lab
 from .utils import (
     SDWAN_CTRL_NODE_DEFS,
+    Certs,
     check_serial_file_match,
     collect_control_components,
     configure_manager,
     connect_cml,
     console,
     dump_topology,
+    enroll_cluster_manager,
+    ensure_cluster_ip_configured,
     extract_org_name,
     load_certs,
     onboard_control_components,
@@ -184,6 +187,12 @@ def run(
                     progress.update(task, description="Restoring network hierarchy...")
                     _restore_mrf(client, json.loads(mrf_path.read_text()))
 
+                client = _restore_cluster(
+                    client, lab, certs, pki,
+                    manager_ip, manager_port, manager_user, manager_password, version,
+                    on_status=lambda s: progress.update(task, description=s),
+                )
+
                 progress.update(task, description="Starting edge nodes...")
                 edge_uuids = _inject_otps_and_start_edges(
                     lab, client, ca_chain=certs.chain if pki == "enterprise" else ""
@@ -308,9 +317,11 @@ def _patch_topology(
     )
 
     nodes = topology_nodes(topology)
+    primary_manager_id = _find_primary_manager_id(topology)
     for node in nodes:
         node_def = node.get("node_definition", "")
         if node_def == "cat-sdwan-manager":
+            is_primary = node.get("id") == primary_manager_id
             cfg: str = node.get("configuration", "")
             encrypted = sha512_crypt(manager_password)
             cfg = re.sub(r"<password>(\S+)</password>", f"<password>{encrypted}</password>", cfg)
@@ -332,16 +343,17 @@ def _patch_topology(
                     cfg,
                     count=1,
                 )
-            if m := re.search(
-                r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<address>)([\d./]+)(</address>)",
-                cfg,
-            ):
-                cfg = cfg.replace(m.group(0), f"{m.group(1)}{manager_ip}{manager_mask}{m.group(3)}")
-            if m := re.search(
-                r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<next-hop>[\s\S]+?<address>)([\d.]+)(</address>)",
-                cfg,
-            ):
-                cfg = cfg.replace(m.group(0), f"{m.group(1)}{manager_gateway}{m.group(3)}")
+            if is_primary:
+                if m := re.search(
+                    r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<address>)([\d./]+)(</address>)",
+                    cfg,
+                ):
+                    cfg = cfg.replace(m.group(0), f"{m.group(1)}{manager_ip}{manager_mask}{m.group(3)}")
+                if m := re.search(
+                    r"(<vpn-instance>[\s\S]+?<vpn-id>512</vpn-id>[\s\S]+?<next-hop>[\s\S]+?<address>)([\d.]+)(</address>)",
+                    cfg,
+                ):
+                    cfg = cfg.replace(m.group(0), f"{m.group(1)}{manager_gateway}{m.group(3)}")
             node_defs = cml.definitions.node_definitions()
             mgr_def = next((nd for nd in node_defs if nd["id"] == node_def), None)
             sim = mgr_def.get("sim", {}) if mgr_def else {}
@@ -349,7 +361,7 @@ def _patch_topology(
             if disk_driver == "virtio":
                 cfg = cfg.replace('"/dev/sdb"', '"/dev/vdb"').replace("[ sdb,", "[ vdb,")
             node["configuration"] = cfg
-            if patty:
+            if is_primary and patty:
                 node.setdefault("tags", [])
                 pat_tag = f"pat:{manager_port}:443"
                 if pat_tag not in node["tags"]:
@@ -358,6 +370,92 @@ def _patch_topology(
             node["image_definition"] = f"{node_def}-{control_version}"
         if edge_version and node_def == "cat-sdwan-edge":
             node["image_definition"] = f"{node_def}-{edge_version}"
+
+
+def _find_primary_manager_id(topology: Any) -> str | None:
+    nodes = topology_nodes(topology)
+    ext_ids = {n["id"] for n in nodes if n.get("node_definition") == "external_connector"}
+    manager_ids = {n["id"] for n in nodes if n.get("node_definition") == "cat-sdwan-manager"}
+    for link in topology.get("links", []):
+        n1, n2 = link.get("n1"), link.get("n2")
+        i1, i2 = link.get("i1"), link.get("i2")
+        if n1 in ext_ids and n2 in manager_ids and i2 == "i0":
+            return n2
+        if n2 in ext_ids and n1 in manager_ids and i1 == "i0":
+            return n1
+    return None
+
+
+def _restore_cluster(
+    client: ManagerClient,
+    lab: Any,
+    certs: Certs,
+    pki: Literal["enterprise", "cisco"],
+    manager_host: str,
+    manager_port: int,
+    manager_user: str,
+    manager_password: str,
+    version: str,
+    on_status: Callable[[str], None],
+) -> ManagerClient:
+    secondary_managers = [
+        n for n in lab.nodes()
+        if n.node_definition == "cat-sdwan-manager" and not _manager_connected_to_external(n)
+    ]
+    if not secondary_managers:
+        return client
+
+    on_status("Checking cluster IP configuration...")
+    ensure_cluster_ip_configured(
+        client, manager_user, manager_password, on_status=on_status,
+    )
+    client = wait_for_manager(manager_host, manager_port, manager_user, manager_password, version)
+
+    on_status("Waiting for secondary managers to boot...")
+    for node in secondary_managers:
+        node.wait_until_converged()
+
+    for node in secondary_managers:
+        m = re.search(r"<system-ip>100\.0\.0\.(\d+)</system-ip>", node.configuration or "")
+        if not m:
+            log.error("Cannot determine cluster IP for %s — skipping.", node.label)
+            continue
+        num = m.group(1)
+        cluster_ip = f"172.16.254.{num}"
+
+        entries = client.get_cluster_management_list()
+        enrolled = any(
+            n.get("configJson", {}).get("deviceIP") == cluster_ip
+            for entry in entries
+            for n in entry.get("data", [])
+        )
+        if enrolled:
+            log.info("%s already enrolled in cluster, skipping.", node.label)
+            continue
+
+        persona_m = re.search(r'"persona":"([^"]+)"', node.configuration or "")
+        persona = persona_m.group(1) if persona_m else "COMPUTE_AND_DATA"
+
+        on_status(f"Adding {node.label} to cluster...")
+        client = enroll_cluster_manager(
+            client, cluster_ip, persona,
+            manager_host, manager_port, manager_user, manager_password, version,
+            certs, pki, node.label, on_status=on_status,
+        )
+
+    return client
+
+
+def _manager_connected_to_external(node: Any) -> bool:
+    try:
+        eth0 = node.get_interface_by_label("eth0")
+    except Exception:
+        return False
+    if not eth0.connected or eth0.link is None:
+        return False
+    link = eth0.link
+    other = link.interface_b if link.interface_a.node == node else link.interface_a
+    return other.node.node_definition == "external_connector"
 
 
 def _start_control_plane(lab: Any) -> None:

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -634,7 +634,8 @@ def enroll_cluster_manager(
     label: str,
     on_status: Callable[[str], None] = lambda _: None,
 ) -> ManagerClient:
-    # cluster IPs are 172.16.254.N and VPN0 IPs are 172.16.0.N — same last octet by deploy convention
+    # cluster IPs are 172.16.254.N and VPN0 IPs are 172.16.0.N
+    # — same last octet by deploy convention
     vpn0_ip = "172.16.0." + cluster_ip.split(".")[-1]
 
     client.add_cluster_node(cluster_ip, persona, manager_user, manager_password)

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -356,8 +356,8 @@ def wait_for_edges_onboarded(
 
 VALIDATOR_FQDN = "validator.sdwan.local"
 
-_MANAGER_BOOT_RETRIES = 120
-_MANAGER_BOOT_INTERVAL = 30
+MANAGER_BOOT_RETRIES = 120
+MANAGER_BOOT_INTERVAL = 30
 
 
 def extract_org_name(path: Path) -> str:
@@ -384,11 +384,11 @@ def wait_for_manager(
     manager_user: str,
     manager_password: str,
     version: str,
-    on_status: Callable[[str], None],
+    on_status: Callable[[str], None] = lambda _: None,
 ) -> ManagerClient:
     use_diagnostic = int(version.split(".")[0]) >= 26
     client = ManagerClient(manager_ip, manager_port, manager_user, manager_password)
-    for _ in range(_MANAGER_BOOT_RETRIES):
+    for _ in range(MANAGER_BOOT_RETRIES):
         if use_diagnostic:
             boot = _query_boot_diagnostic(manager_ip, manager_port)
             if boot:
@@ -400,7 +400,7 @@ def wait_for_manager(
             return client
         except (ManagerAPIError, requests.exceptions.RequestException):
             pass
-        time.sleep(_MANAGER_BOOT_INTERVAL)
+        time.sleep(MANAGER_BOOT_INTERVAL)
     log.error("SD-WAN Manager did not become available within 60 minutes.")
     raise typer.Exit(1)
 
@@ -594,6 +594,78 @@ def trigger_rediscovery(client: ManagerClient) -> None:
     if reachable:
         client.rediscover_devices(reachable)
         log.info("Network rediscovery triggered for %d devices", len(reachable))
+
+
+def ensure_cluster_ip_configured(
+    client: ManagerClient,
+    manager_user: str,
+    manager_password: str,
+    on_status: Callable[[str], None] = lambda _: None,
+    persona: str = "COMPUTE_AND_DATA",
+) -> None:
+    cluster_list = client.get_cluster_management_list()
+    entry = cluster_list[0] if cluster_list else {}
+    if entry.get("isIPConfigured"):
+        log.info("Cluster IP already configured.")
+        return
+    if len(entry.get("data", [])) > 1:
+        log.info("Multiple vManage nodes present, cluster already set up.")
+        return
+    system_ip = client.get_local_system_ip()
+    cluster_ip = client.get_vpn0_interface_ip(system_ip, "eth2")
+    on_status("Configuring cluster IP on primary manager...")
+    client.setup_cluster_ip(cluster_ip, persona, manager_user, manager_password)
+    log.info("Cluster IP configured: %s — waiting for NMS restart.", cluster_ip)
+    on_status("Waiting for Manager to restart after cluster IP setup...")
+    time.sleep(120)
+
+
+def enroll_cluster_manager(
+    client: ManagerClient,
+    cluster_ip: str,
+    persona: str,
+    manager_host: str,
+    manager_port: int,
+    manager_user: str,
+    manager_password: str,
+    version: str,
+    certs: "Certs",
+    pki: Literal["enterprise", "cisco"],
+    label: str,
+    on_status: Callable[[str], None] = lambda _: None,
+) -> ManagerClient:
+    # cluster IPs are 172.16.254.N and VPN0 IPs are 172.16.0.N — same last octet by deploy convention
+    vpn0_ip = "172.16.0." + cluster_ip.split(".")[-1]
+
+    client.add_cluster_node(cluster_ip, persona, manager_user, manager_password)
+    client.logout()
+    on_status(f"Waiting for Manager to restart after adding {label}...")
+    time.sleep(120)
+    client = wait_for_manager(manager_host, manager_port, manager_user, manager_password, version)
+    on_status(f"Waiting for {label} to be ready in cluster...")
+
+    uuid: str | None = None
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        try:
+            entries = client.get_cluster_management_list()
+            for n in (entries[0].get("data", []) if entries else []):
+                cfg = n.get("configJson", {})
+                if cfg.get("deviceIP") == cluster_ip and cfg.get("state", "").lower() == "ready":
+                    uuid = cfg.get("uuid")
+                    break
+            if uuid:
+                break
+        except ManagerAPIError:
+            pass
+        time.sleep(10)
+    if not uuid:
+        raise ManagerAPIError(f"Cluster node {cluster_ip} did not reach Ready state.")
+
+    client.update_device_connection(uuid, vpn0_ip, "admin", manager_password)
+    sign_device_cert(client, certs, vpn0_ip, pki=pki)
+    log.info("Cluster node %s enrolled and certificate signed.", cluster_ip)
+    return client
 
 
 class _TopologyDumper(yaml.SafeDumper):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 import zipfile
 from pathlib import Path
 
@@ -194,3 +195,39 @@ class TestSaveDirectory:
         output = tmp_path / "deep" / "nested" / "backup"
         _save_directory(output, "nodes: []\n", self._make_manager_dir(tmp_path), [])
         assert output.is_dir()
+
+
+class TestClusterPersonas:
+    def _cluster_list(self, entries: list[dict]) -> list[dict]:
+        return [{"isIPConfigured": True, "data": entries}]
+
+    def test_extracts_persona_by_hostname(self) -> None:
+        cluster_list = self._cluster_list([
+            {"configJson": {"host-name": "Manager01", "persona": "COMPUTE_AND_DATA"}},
+            {"configJson": {"host-name": "Manager02", "persona": "DATA"}},
+        ])
+        personas = {
+            n["configJson"]["host-name"]: n["configJson"].get("persona", "COMPUTE_AND_DATA")
+            for entry in cluster_list
+            for n in entry.get("data", [])
+            if "configJson" in n and "host-name" in n["configJson"]
+        }
+        assert personas == {"Manager01": "COMPUTE_AND_DATA", "Manager02": "DATA"}
+
+    def test_hostname_parsed_from_config_xml(self) -> None:
+        config_xml = (
+            '<config xmlns="http://tail-f.com/ns/config/1.0">'
+            '  <system xmlns="http://viptela.com/system">'
+            '    <host-name>Manager02</host-name>'
+            '    <system-ip>100.0.0.2</system-ip>'
+            '  </system>'
+            '</config>'
+        )
+        m = re.search(r"<host-name>([^<]+)</host-name>", config_xml)
+        assert m is not None
+        assert m.group(1) == "Manager02"
+
+    def test_default_persona_when_not_in_cluster_list(self) -> None:
+        personas: dict[str, str] = {}
+        persona = personas.get("Manager03", "COMPUTE_AND_DATA")
+        assert persona == "COMPUTE_AND_DATA"

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,0 +1,67 @@
+from catalyst_sdwan_lab.tasks.restore import _find_primary_manager_id
+
+
+class TestFindPrimaryManagerId:
+    def _topology(self, nodes: list[dict], links: list[dict]) -> dict:
+        return {"nodes": nodes, "links": links}
+
+    def test_finds_manager_connected_to_external_via_eth0(self) -> None:
+        topology = self._topology(
+            nodes=[
+                {"id": "n0", "node_definition": "cat-sdwan-manager"},
+                {"id": "n5", "node_definition": "external_connector"},
+            ],
+            links=[{"n1": "n5", "n2": "n0", "i1": "i0", "i2": "i0"}],
+        )
+        assert _find_primary_manager_id(topology) == "n0"
+
+    def test_link_reversed_still_found(self) -> None:
+        topology = self._topology(
+            nodes=[
+                {"id": "n0", "node_definition": "cat-sdwan-manager"},
+                {"id": "n5", "node_definition": "external_connector"},
+            ],
+            links=[{"n1": "n0", "n2": "n5", "i1": "i0", "i2": "i0"}],
+        )
+        assert _find_primary_manager_id(topology) == "n0"
+
+    def test_secondary_manager_not_matched(self) -> None:
+        topology = self._topology(
+            nodes=[
+                {"id": "n0", "node_definition": "cat-sdwan-manager"},
+                {"id": "n1", "node_definition": "cat-sdwan-manager"},
+                {"id": "n5", "node_definition": "external_connector"},
+            ],
+            links=[
+                {"n1": "n5", "n2": "n0", "i1": "i0", "i2": "i0"},
+                {"n1": "n1", "n2": "n3", "i1": "i2", "i2": "i0"},
+            ],
+        )
+        assert _find_primary_manager_id(topology) == "n0"
+
+    def test_non_eth0_link_not_matched(self) -> None:
+        topology = self._topology(
+            nodes=[
+                {"id": "n0", "node_definition": "cat-sdwan-manager"},
+                {"id": "n5", "node_definition": "external_connector"},
+            ],
+            links=[{"n1": "n5", "n2": "n0", "i1": "i0", "i2": "i1"}],
+        )
+        assert _find_primary_manager_id(topology) is None
+
+    def test_no_external_connector_returns_none(self) -> None:
+        topology = self._topology(
+            nodes=[{"id": "n0", "node_definition": "cat-sdwan-manager"}],
+            links=[],
+        )
+        assert _find_primary_manager_id(topology) is None
+
+    def test_non_manager_connected_to_external_not_matched(self) -> None:
+        topology = self._topology(
+            nodes=[
+                {"id": "n0", "node_definition": "cat-sdwan-controller"},
+                {"id": "n5", "node_definition": "external_connector"},
+            ],
+            links=[{"n1": "n5", "n2": "n0", "i1": "i0", "i2": "i0"}],
+        )
+        assert _find_primary_manager_id(topology) is None


### PR DESCRIPTION
## Description

- Add Manager clustering support via `csdwan add managers <version>`
  - Deploys additional Manager nodes into the CML topology with a dedicated Cluster switch
  - Configures cluster IP on the primary Manager and enrolls new nodes one-by-one
  - Supports `--persona` flag (`compute-and-data` default, `compute`, `data`)
  - Certificates signed automatically after each node reaches Ready state (enterprise and Cisco PKI)
- Update `backup` to capture cluster node personas from the live cluster management API and embed them in each Manager's backed-up cloud-init
- Update `restore` to re-enroll secondary Manager nodes into the cluster after Sastre restore