### PR TITLE
refactor logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Certificates signed automatically after each node reaches Ready state (enterprise and Cisco PKI)
 - Update `backup` to capture cluster node personas from the live cluster management API and embed them in each Manager's backed-up cloud-init
 - Update `restore` to re-enroll secondary Manager nodes into the cluster after Sastre restore
+- Refactor progress reporting across all tasks to use a shared `task_progress` context manager and `make_updater` helper; every spinner update now also emits a `log.info` event, making task progress visible to log consumers (e.g. MCP server)
 
 # Catalyst SD-WAN Lab 3.0.1 [Jun 24, 2026]
 

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -8,7 +8,6 @@ from typing import Any, Literal
 import typer
 from jinja2 import Environment, FileSystemLoader
 from rich.markup import escape
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from virl2_client import ClientLibrary
 from virl2_client.exceptions import InterfaceNotFound
 from virl2_client.models.interface import Interface
@@ -42,6 +41,7 @@ from .utils import (
     resolve_image,
     sha512_crypt,
     sign_device_cert,
+    task_progress,
     trigger_rediscovery,
     wait_for_edges_onboarded,
     wait_for_manager,
@@ -84,20 +84,14 @@ def run_control_component(
     node_def = "cat-sdwan-controller" if is_ctrl else "cat-sdwan-validator"
     certs = load_certs()
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
-        progress.update(task, description="Checking lab and images...")
+        update("Checking lab and images...")
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, node_def, version)
 
-        progress.update(task, description="Connecting to SD-WAN Manager...")
+        update("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
             pki = client.get_certificate_signing()
@@ -113,10 +107,7 @@ def run_control_component(
             device_ips: list[str] = []
             for i in range(count):
                 num = _next_device_num(lab, num_re)
-                progress.update(
-                    task,
-                    description=f"Adding {label_prefix}{num} to CML ({i + 1}/{count})...",
-                )
+                update(f"Adding {label_prefix}{num} to CML ({i + 1}/{count})...")
                 extra = (
                     {"controller_num": num, "validator_fqdn": VALIDATOR_FQDN}
                     if is_ctrl
@@ -141,18 +132,15 @@ def run_control_component(
                 )
 
             for i, (node, ip) in enumerate(zip(nodes, device_ips), 1):
-                progress.update(task, description=f"Waiting for {device_type}s to boot...")
+                update(f"Waiting for {device_type}s to boot...")
                 node.wait_until_converged()
-                progress.update(
-                    task,
-                    description=f"Waiting for {device_type} to be reachable ({i}/{count})...",
-                )
+                update(f"Waiting for {device_type} to be reachable ({i}/{count})...")
                 _add_to_manager_retrying(client, ip, personality, timeout=_BOOT_TIMEOUT)
 
-            progress.update(task, description=f"Waiting for {device_type} CSRs...")
+            update(f"Waiting for {device_type} CSRs...")
             _wait_for_csrs(client, device_ips, timeout=_CSR_POLL_TIMEOUT)
 
-            progress.update(task, description=f"Signing {device_type} certificates...")
+            update(f"Signing {device_type} certificates...")
             with ThreadPoolExecutor() as pool:
                 futures = [
                     pool.submit(sign_device_cert, client, certs, ip, pki=pki)
@@ -166,17 +154,17 @@ def run_control_component(
                     f"100.0.0.{ip.split('.')[-1] if '.' in ip else ip.split(':')[-1]}"
                     for ip in device_ips
                 }
-                progress.update(task, description="Waiting for controllers to reconnect...")
+                update("Waiting for controllers to reconnect...")
                 _wait_for_controllers_ready(client, system_ips, timeout=_CSR_POLL_TIMEOUT)
-                progress.update(task, description="Attaching controller template...")
+                update("Attaching controller template...")
                 assert template_id is not None
                 _attach_controller_template(client, ip_type, template_id, system_ips)
             else:
-                progress.update(task, description="Updating Gateway DNS entries...")
+                update("Updating Gateway DNS entries...")
                 _update_gateway_dns(
                     cml_host, cml_user, cml_password, lab, lab_name, device_ips,
                 )
-            progress.update(task, description="Triggering network rediscovery...")
+            update("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -204,23 +192,17 @@ def run_edge(
     cpus: int | None = None,
     ram: int | None = None,
 ) -> None:
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
-        progress.update(task, description="Checking lab and images...")
+        update("Checking lab and images...")
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, "cat-sdwan-edge", version)
 
-        progress.update(task, description="Connecting to SD-WAN Manager...")
+        update("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
-            progress.update(task, description="Checking available edge devices...")
+            update("Checking available edge devices...")
             vedges = client.get_vedges()
             free_uuids = [
                 v["uuid"]
@@ -233,7 +215,7 @@ def run_edge(
                 )
                 raise typer.Exit(1)
 
-            progress.update(task, description="Looking up edge config group...")
+            update("Looking up edge config group...")
             config_group_id = _get_config_group_id(client, "edge_basic")
 
             start = _next_system_ip_num(lab, vedges)
@@ -271,22 +253,20 @@ def run_edge(
                     ]
                 devices_vars.append({"device-id": uuid, "variables": variables})
 
-            progress.update(task, description="Associating config group...")
+            update("Associating config group...")
             client.associate_config_group(config_group_id, uuids)
-            progress.update(task, description="Setting device variables...")
+            update("Setting device variables...")
             client.set_config_group_variables(config_group_id, devices_vars)
-            progress.update(task, description="Deploying config group...")
+            update("Deploying config group...")
             task_id = client.deploy_config_group(config_group_id, uuids)
             client.wait_for_task(task_id)
 
-            progress.update(task, description="Fetching bootstrap configs...")
+            update("Fetching bootstrap configs...")
             bootstrap_configs = {uuid: client.get_bootstrap_config(uuid) for uuid in uuids}
 
             nodes: list[Node] = []
             for i, (num, uuid) in enumerate(zip(nums, uuids), 1):
-                progress.update(
-                    task, description=f"Adding Edge{num} to CML ({i}/{count})..."
-                )
+                update(f"Adding Edge{num} to CML ({i}/{count})...")
                 node = _add_wan_edge_node(
                     lab, f"Edge{num}", image_id, bootstrap_configs[uuid], True, cpus, ram,
                 )
@@ -294,21 +274,19 @@ def run_edge(
                 nodes.append(node)
 
             for node in nodes:
-                progress.update(
-                    task, description=f"Waiting for {'edges' if count > 1 else 'edge'} to boot..."
-                )
+                update(f"Waiting for {'edges' if count > 1 else 'edge'} to boot...")
                 node.wait_until_converged()
 
-            progress.update(task, description=f"Waiting for edges to onboard (0/{count})...")
+            update(f"Waiting for edges to onboard (0/{count})...")
             wait_for_edges_onboarded(
                 client,
                 uuids,
                 timeout=_BOOT_TIMEOUT,
-                on_progress=lambda done, total: progress.update(
-                    task, description=f"Waiting for edges to onboard ({done}/{total})..."
+                on_progress=lambda done, total: update(
+                    f"Waiting for edges to onboard ({done}/{total})..."
                 ),
             )
-            progress.update(task, description="Triggering network rediscovery...")
+            update("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -331,23 +309,17 @@ def run_sdrouting(
     cpus: int | None = None,
     ram: int | None = None,
 ) -> None:
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
-        progress.update(task, description="Checking lab and images...")
+        update("Checking lab and images...")
         lab, manager_ip, manager_port = find_lab(cml, lab_name)
         ip_type = detect_ip_type(lab)
         image_id = resolve_image(cml, "cat-sdwan-edge", version)
 
-        progress.update(task, description="Connecting to SD-WAN Manager...")
+        update("Connecting to SD-WAN Manager...")
         client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
         try:
-            progress.update(task, description="Checking available SD-Routing devices...")
+            update("Checking available SD-Routing devices...")
             vedges = client.get_vedges()
             free_uuids = [
                 v["uuid"]
@@ -365,7 +337,7 @@ def run_sdrouting(
             nums = [str(start + i) for i in range(count)]
             uuids = free_uuids[:count]
 
-            progress.update(task, description="Looking up SD-Routing config group...")
+            update("Looking up SD-Routing config group...")
             config_group_id = _get_config_group_id(client, "sdrouting_basic")
 
             devices_vars: list[dict[str, Any]] = []
@@ -395,17 +367,17 @@ def run_sdrouting(
                     ]
                 devices_vars.append({"device-id": uuid, "variables": variables})
 
-            progress.update(task, description="Associating config group...")
+            update("Associating config group...")
             client.associate_config_group(config_group_id, uuids)
-            progress.update(task, description="Setting device variables...")
+            update("Setting device variables...")
             client.set_config_group_variables(
                 config_group_id, devices_vars, solution="sd-routing"
             )
-            progress.update(task, description="Deploying config group...")
+            update("Deploying config group...")
             task_id = client.deploy_config_group(config_group_id, uuids)
             client.wait_for_task(task_id)
 
-            progress.update(task, description="Fetching bootstrap configs...")
+            update("Fetching bootstrap configs...")
             bootstrap_configs = {
                 uuid: client.get_bootstrap_config(uuid, wanif="GigabitEthernet1")
                 for uuid in uuids
@@ -413,9 +385,7 @@ def run_sdrouting(
 
             nodes: list[Node] = []
             for i, (num, uuid) in enumerate(zip(nums, uuids), 1):
-                progress.update(
-                    task, description=f"Adding SD-Edge{num} to CML ({i}/{count})..."
-                )
+                update(f"Adding SD-Edge{num} to CML ({i}/{count})...")
                 node = _add_wan_edge_node(
                     lab, f"SD-Edge{num}", image_id, bootstrap_configs[uuid], False, cpus, ram,
                 )
@@ -423,28 +393,25 @@ def run_sdrouting(
                 nodes.append(node)
 
             for node in nodes:
-                progress.update(task, description="Waiting for SD-Routing edges to boot...")
+                update("Waiting for SD-Routing edges to boot...")
                 node.wait_until_converged()
-                progress.update(task, description=f"Checking default route on {node.label}...")
+                update(f"Checking default route on {node.label}...")
                 if fix_sdrouting_default_route(
                     cml_host, cml_user, cml_password, lab.title or lab_name, node.label,
                     console=console,
                 ):
                     node.wait_until_converged()
 
-            progress.update(
-                task, description=f"Waiting for SD-Routing edges to onboard (0/{count})..."
-            )
+            update(f"Waiting for SD-Routing edges to onboard (0/{count})...")
             wait_for_edges_onboarded(
                 client,
                 uuids,
                 timeout=_BOOT_TIMEOUT,
-                on_progress=lambda done, total: progress.update(
-                    task,
-                    description=f"Waiting for SD-Routing edges to onboard ({done}/{total})...",
+                on_progress=lambda done, total: update(
+                    f"Waiting for SD-Routing edges to onboard ({done}/{total})..."
                 ),
             )
-            progress.update(task, description="Triggering network rediscovery...")
+            update("Triggering network rediscovery...")
             trigger_rediscovery(client)
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -718,14 +685,12 @@ def run_managers(
     cml = connect_cml(cml_host, cml_user, cml_password)
     lab, manager_host, manager_port = find_lab(cml, lab_name)
 
-    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
-                  transient=True, console=console) as progress:
-        task = progress.add_task("Setting up Cluster switch...")
+    with task_progress(console, initial="Setting up Cluster switch...") as update:
         cluster = _ensure_cluster_switch(lab)
-        progress.update(task, description="Connecting existing managers to Cluster switch...")
+        update("Connecting existing managers to Cluster switch...")
         _connect_managers_to_cluster(lab, cluster)
 
-        progress.update(task, description="Checking cluster IP configuration...")
+        update("Checking cluster IP configuration...")
         client = connect_manager(manager_host, manager_port, manager_user, manager_password)
         try:
             org_name = client.get_organization() or ""
@@ -733,7 +698,7 @@ def run_managers(
             pki = client.get_certificate_signing()
             ensure_cluster_ip_configured(
                 client, manager_user, manager_password, persona=persona,
-                on_status=lambda s: progress.update(task, description=s),
+                on_status=update,
             )
         except ManagerAPIError as e:
             log.error("%s", e)
@@ -741,29 +706,29 @@ def run_managers(
         finally:
             client.logout()
 
-        progress.update(task, description=f"Adding {count} manager node(s) to CML...")
+        update(f"Adding {count} manager node(s) to CML...")
         new_nodes = _create_manager_nodes(
             lab, cluster, cml, count, version,
             manager_user, manager_password, org_name, ip_type, persona, cpus, ram,
         )
 
-        progress.update(task, description="Waiting for managers to boot...")
+        update("Waiting for managers to boot...")
         for node, _ in new_nodes:
             node.wait_until_converged()
 
-        progress.update(task, description="Waiting for primary Manager...")
+        update("Waiting for primary Manager...")
         client = wait_for_manager(
             manager_host, manager_port, manager_user, manager_password, version,
         )
         certs = load_certs()
         try:
             for node, cluster_ip in new_nodes:
-                progress.update(task, description=f"Adding {node.label} to cluster...")
+                update(f"Adding {node.label} to cluster...")
                 client = enroll_cluster_manager(
                     client, cluster_ip, persona,
                     manager_host, manager_port, manager_user, manager_password, version,
                     certs, pki, node.label,
-                    on_status=lambda s: progress.update(task, description=s),
+                    on_status=update,
                 )
         except ManagerAPIError as e:
             log.error("%s", e)

--- a/src/catalyst_sdwan_lab/tasks/backup.py
+++ b/src/catalyst_sdwan_lab/tasks/backup.py
@@ -11,7 +11,6 @@ import typer
 import yaml
 from jinja2 import Environment, FileSystemLoader
 from rich.markup import escape
-from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from catalyst_sdwan_lab.manager_client import ManagerAPIError
 from catalyst_sdwan_lab.ssh_client import extract_control_config, extract_edge_config
@@ -26,6 +25,7 @@ from .utils import (
     find_lab,
     load_certs,
     run_sastre_task,
+    task_progress,
     topology_nodes,
 )
 
@@ -67,19 +67,13 @@ def run(
     certs = load_certs()
     cml = connect_cml(cml_host, cml_user, cml_password)
     try:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=console,
-            transient=True,
-        ) as progress:
-            task = progress.add_task("Locating lab...")
+        with task_progress(console, initial="Locating lab...") as update:
             lab, manager_ip, manager_port = find_lab(cml, lab_name)
             if not lab.is_active():
                 log.error("Lab '%s' is not active — start the lab before running backup.", lab_name)
                 raise typer.Exit(1)
 
-            progress.update(task, description="Connecting to SD-WAN Manager...")
+            update("Connecting to SD-WAN Manager...")
             client = connect_manager(manager_ip, manager_port, manager_user, manager_password)
 
             try:
@@ -98,10 +92,7 @@ def run(
                 ]
                 for i, node in enumerate(cml_extract_nodes, 1):
                     n_total = len(cml_extract_nodes)
-                    progress.update(
-                        task,
-                        description=f"Extracting CML node configurations ({i}/{n_total})...",
-                    )
+                    update(f"Extracting CML node configurations ({i}/{n_total})...")
                     try:
                         node.extract_configuration()
                         log.info("Extracted config from %s via CML.", node.label)
@@ -110,7 +101,7 @@ def run(
                             "Node '%s' does not support config extract — skipping.", node.label
                         )
 
-                progress.update(task, description="Downloading CML topology...")
+                update("Downloading CML topology...")
                 topology_str = lab.download()
                 topology: Any = yaml.safe_load(topology_str)
 
@@ -133,10 +124,7 @@ def run(
                 for i, node in enumerate(extract_nodes, 1):
                     node_def = node.node_definition
                     if node_def in SDWAN_CTRL_NODE_DEFS:
-                        progress.update(
-                            task,
-                            description=f"Extracting config from {node.label} ({i}/{total})...",
-                        )
+                        update(f"Extracting config from {node.label} ({i}/{total})...")
                         if node_def == "cat-sdwan-manager":
                             node_user, node_pass = manager_user, manager_password
                         else:
@@ -159,10 +147,7 @@ def run(
                         )
                         _update_node_configuration(topology, node.label, cloud_init)
                     elif node_def == "cat-sdwan-edge":
-                        progress.update(
-                            task,
-                            description=f"Extracting config from {node.label} ({i}/{total})...",
-                        )
+                        update(f"Extracting config from {node.label} ({i}/{total})...")
                         try:
                             edge_type, config_text, uuid = extract_edge_config(
                                 cml_host, cml_user, cml_password, lab_name, node.label,
@@ -180,12 +165,12 @@ def run(
                         )
                         _update_node_configuration(topology, node.label, cloud_init)
 
-                progress.update(task, description="Backing up SD-WAN Manager configuration...")
+                update("Backing up SD-WAN Manager configuration...")
                 with tempfile.TemporaryDirectory() as tmpdir:
                     _run_sastre_backup(
                         manager_ip, manager_port, manager_user, manager_password, Path(tmpdir)
                     )
-                    progress.update(task, description="Backing up network hierarchy...")
+                    update("Backing up network hierarchy...")
                     mrf_data = client.get_network_hierarchy()
 
                     if output is None:
@@ -193,7 +178,7 @@ def run(
                         suffix = "" if directory else ".zip"
                         output = Path(f"{lab_name}-{ts}{suffix}")
 
-                    progress.update(task, description="Saving backup...")
+                    update("Saving backup...")
                     updated_topology = dump_topology(topology)
                     if directory:
                         _save_directory(output, updated_topology, Path(tmpdir), mrf_data)

--- a/src/catalyst_sdwan_lab/tasks/delete.py
+++ b/src/catalyst_sdwan_lab/tasks/delete.py
@@ -2,9 +2,8 @@ import logging
 
 import typer
 from rich.markup import escape
-from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from .utils import connect_cml, console
+from .utils import connect_cml, console, task_progress
 
 log = logging.getLogger(__name__)
 
@@ -17,16 +16,10 @@ def run(cml_host: str, cml_user: str, cml_password: str, lab_name: str, *, force
         if not confirmed:
             raise typer.Exit(0)
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
         try:
-            progress.update(task, description="Finding lab...")
+            update("Finding lab...")
             labs = cml.find_labs_by_title(lab_name)
             if not labs:
                 log.error("No lab found with name '%s'.", lab_name)
@@ -38,11 +31,11 @@ def run(cml_host: str, cml_user: str, cml_password: str, lab_name: str, *, force
                 raise typer.Exit(1)
             lab = labs[0]
 
-            progress.update(task, description="Stopping lab...")
+            update("Stopping lab...")
             lab.stop()
-            progress.update(task, description="Wiping lab...")
+            update("Wiping lab...")
             lab.wipe()
-            progress.update(task, description="Removing lab...")
+            update("Removing lab...")
             lab.remove()
         finally:
             cml.logout()

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -11,7 +11,6 @@ from typing import Any, Literal
 import typer
 from jinja2 import Environment, FileSystemLoader
 from rich.markup import escape
-from rich.progress import Progress, SpinnerColumn, TextColumn
 from virl2_client import ClientLibrary
 
 from catalyst_sdwan_lab.manager_client import ManagerAPIError, ManagerClient
@@ -31,6 +30,7 @@ from .utils import (
     onboard_control_components,
     resolve_image,
     sha512_crypt,
+    task_progress,
     trigger_rediscovery,
     wait_for_manager,
 )
@@ -95,24 +95,18 @@ def run(
 
     certs = load_certs()
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
 
-        progress.update(task, description="Checking SD-WAN images...")
+        update("Checking SD-WAN images...")
         images = _check_images(cml, version)
 
         try:
             if retry:
-                progress.update(task, description="Locating existing lab...")
+                update("Locating existing lab...")
                 _find_lab(cml, manager_ip, manager_port)
             else:
-                progress.update(task, description=f"Creating lab {lab_name}...")
+                update(f"Creating lab {lab_name}...")
                 _create_lab(
                     cml,
                     lab_name=lab_name,
@@ -131,20 +125,20 @@ def run(
                     patty=patty,
                 )
 
-            progress.update(task, description="Waiting for SD-WAN Manager...")
+            update("Waiting for SD-WAN Manager...")
             client = wait_for_manager(
                 manager_ip,
                 manager_port,
                 manager_user,
                 manager_password,
                 version,
-                on_status=lambda msg: progress.update(task, description=msg),
+                on_status=update,
             )
             try:
-                progress.update(task, description="Configuring SD-WAN Manager...")
+                update("Configuring SD-WAN Manager...")
                 configure_manager(
                     client, version, org_name, certs.chain, pki=pki,
-                    on_status=lambda msg: progress.update(task, description=msg),
+                    on_status=update,
                     proxy_ip=proxy_ip, proxy_port=proxy_port, no_proxy=no_proxy,
                 )
 
@@ -154,23 +148,23 @@ def run(
                     [("fc00:172:16::201", "vbond"), ("fc00:172:16::101", "vsmart")]
                     if ip_type == "v6"
                     else [("172.16.0.201", "vbond"), ("172.16.0.101", "vsmart")],
-                    on_status=lambda msg: progress.update(task, description=msg),
+                    on_status=update,
                     pki=pki,
                 )
 
-                progress.update(task, description="Uploading serial file...")
+                update("Uploading serial file...")
                 client.upload_serial_file(serial_file)
 
-                progress.update(task, description="Importing basic configuration...")
+                update("Importing basic configuration...")
                 _restore_basic_configuration(client, ip_type)
 
-                progress.update(task, description="Importing controller templates...")
+                update("Importing controller templates...")
                 template_id = _import_controller_templates(client, ip_type)
 
-                progress.update(task, description="Attaching controller template...")
+                update("Attaching controller template...")
                 _attach_controller_template(client, ip_type, template_id)
 
-                progress.update(task, description="Triggering network rediscovery...")
+                update("Triggering network rediscovery...")
                 trigger_rediscovery(client)
             except ManagerAPIError as e:
                 log.error("%s", e)

--- a/src/catalyst_sdwan_lab/tasks/images.py
+++ b/src/catalyst_sdwan_lab/tasks/images.py
@@ -19,7 +19,7 @@ from virl2_client.exceptions import APIError
 
 from catalyst_sdwan_lab.cml_client import upload_image_file
 
-from .utils import SDWAN_ALL_NODE_DEFS, connect_cml, console
+from .utils import SDWAN_ALL_NODE_DEFS, connect_cml, console, make_updater, task_progress
 
 log = logging.getLogger(__name__)
 
@@ -78,9 +78,10 @@ def upload(cml_host: str, cml_user: str, cml_password: str, images_dir: Path) ->
         transient=True,
     ) as progress:
         status = progress.add_task("Connecting to CML...")
+        update = make_updater(progress, status)
         cml = connect_cml(cml_host, cml_user, cml_password)
         try:
-            progress.update(status, description="Checking existing images...")
+            update("Checking existing images...")
             existing = {_normalize_id(img["id"]) for img in cml.definitions.image_definitions()}
             progress.remove_task(status)
 
@@ -118,16 +119,10 @@ def upload(cml_host: str, cml_user: str, cml_password: str, images_dir: Path) ->
 
 
 def list_versions(cml_host: str, cml_user: str, cml_password: str) -> None:
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
         try:
-            progress.update(task, description="Fetching image definitions...")
+            update("Fetching image definitions...")
             all_images = cml.definitions.image_definitions()
             table = Table(title="Catalyst SD-WAN Software Versions")
             table.add_column("Node Type", style="cyan")
@@ -156,9 +151,10 @@ def delete(
         transient=True,
     ) as progress:
         status = progress.add_task("Connecting to CML...")
+        update = make_updater(progress, status)
         cml = connect_cml(cml_host, cml_user, cml_password)
         try:
-            progress.update(status, description="Checking image definitions...")
+            update("Checking image definitions...")
             image_map = {
                 _normalize_id(img["id"]): img
                 for img in cml.definitions.image_definitions()

--- a/src/catalyst_sdwan_lab/tasks/restore.py
+++ b/src/catalyst_sdwan_lab/tasks/restore.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Literal
 import typer
 import yaml
 from rich.markup import escape
-from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from catalyst_sdwan_lab.manager_client import ManagerAPIError, ManagerClient
 from catalyst_sdwan_lab.ssh_client import fix_sdrouting_default_route
@@ -33,6 +32,7 @@ from .utils import (
     resolve_image,
     run_sastre_task,
     sha512_crypt,
+    task_progress,
     topology_nodes,
     trigger_rediscovery,
     wait_for_edges_onboarded,
@@ -76,16 +76,10 @@ def run(
 
     certs = load_certs()
 
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
 
-        progress.update(task, description="Loading backup...")
+        update("Loading backup...")
         topology, manager_configs_dir, backup_tmpdir = _load_backup(backup)
         check_serial_file_match(topology, serial_file)
 
@@ -107,11 +101,11 @@ def run(
                 log.error("Cisco PKI requires Manager version 20.18.2 or later. Got: %s", version)
                 raise typer.Exit(1)
 
-        progress.update(task, description="Checking images...")
+        update("Checking images...")
         _check_images(cml, topology, control_version, edge_version)
 
         if delete_existing:
-            progress.update(task, description="Removing existing lab...")
+            update("Removing existing lab...")
             _delete_lab(cml_host, cml_user, cml_password, lab_name, force=True)
 
         if not retry and not delete_existing:
@@ -125,36 +119,36 @@ def run(
 
         try:
             if retry:
-                progress.update(task, description="Locating existing lab...")
+                update("Locating existing lab...")
                 lab = _find_lab_by_manager(cml, manager_ip, manager_port, patty)
             else:
-                progress.update(task, description="Patching topology...")
+                update("Patching topology...")
                 _patch_topology(
                     topology, lab_name, manager_ip, manager_mask, manager_gateway,
                     manager_port, manager_user, manager_password, patty,
                     control_version, edge_version, cml,
                 )
                 topology_yaml = dump_topology(topology)
-                progress.update(task, description="Importing lab into CML...")
+                update("Importing lab into CML...")
                 lab = cml.import_lab(topology_yaml)
 
-            progress.update(task, description="Starting control plane...")
+            update("Starting control plane...")
             _start_control_plane(lab)
 
-            progress.update(task, description="Waiting for SD-WAN Manager...")
+            update("Waiting for SD-WAN Manager...")
             client = wait_for_manager(
                 manager_ip, manager_port, manager_user, manager_password, version,
-                lambda s: progress.update(task, description=s),
+                on_status=update,
             )
             try:
-                progress.update(task, description="Configuring SD-WAN Manager...")
+                update("Configuring SD-WAN Manager...")
                 configure_manager(
                     client, version, org_name, certs.chain, pki=pki,
-                    on_status=lambda s: progress.update(task, description=s),
+                    on_status=update,
                     proxy_ip=proxy_ip, proxy_port=proxy_port, no_proxy=no_proxy,
                 )
 
-                progress.update(task, description="Onboarding control components...")
+                update("Onboarding control components...")
                 components = collect_control_components(lab)
                 if not components:
                     log.error(
@@ -164,36 +158,36 @@ def run(
                     raise typer.Exit(1)
                 onboard_control_components(
                     client, certs, components,
-                    lambda s: progress.update(task, description=s),
+                    on_status=update,
                     pki=pki,
                 )
 
-                progress.update(task, description="Uploading serial file...")
+                update("Uploading serial file...")
                 client.upload_serial_file(serial_file)
 
-                progress.update(task, description="Patching Sastre controller UUIDs...")
+                update("Patching Sastre controller UUIDs...")
                 _patch_sastre_controller_uuids(manager_configs_dir, client)
 
-                progress.update(task, description="Patching config group passwords...")
+                update("Patching config group passwords...")
                 _patch_config_group_passwords(manager_configs_dir)
 
-                progress.update(task, description="Restoring Manager configuration...")
+                update("Restoring Manager configuration...")
                 _run_sastre_restore(
                     manager_ip, manager_port, manager_user, manager_password, manager_configs_dir
                 )
 
                 mrf_path = manager_configs_dir / "mrf.json"
                 if mrf_path.exists():
-                    progress.update(task, description="Restoring network hierarchy...")
+                    update("Restoring network hierarchy...")
                     _restore_mrf(client, json.loads(mrf_path.read_text()))
 
                 client = _restore_cluster(
                     client, lab, certs, pki,
                     manager_ip, manager_port, manager_user, manager_password, version,
-                    on_status=lambda s: progress.update(task, description=s),
+                    on_status=update,
                 )
 
-                progress.update(task, description="Starting edge nodes...")
+                update("Starting edge nodes...")
                 edge_uuids = _inject_otps_and_start_edges(
                     lab, client, ca_chain=certs.chain if pki == "enterprise" else ""
                 )
@@ -203,7 +197,7 @@ def run(
                         continue
                     if "SD-Routing : true" not in (node.configuration or ""):
                         continue
-                    progress.update(task, description=f"Checking default route on {node.label}...")
+                    update(f"Checking default route on {node.label}...")
                     node.wait_until_converged()
                     if fix_sdrouting_default_route(
                         cml_host, cml_user, cml_password, lab.title or lab_name, node.label,
@@ -213,18 +207,16 @@ def run(
 
                 if edge_uuids:
                     total_edges = len(edge_uuids)
-                    progress.update(
-                        task, description=f"Waiting for edges to onboard... (0/{total_edges})"
-                    )
+                    update(f"Waiting for edges to onboard... (0/{total_edges})")
                     wait_for_edges_onboarded(
                         client,
                         edge_uuids,
-                        on_progress=lambda done, total: progress.update(
-                            task, description=f"Waiting for edges to onboard... ({done}/{total})"
+                        on_progress=lambda done, total: update(
+                            f"Waiting for edges to onboard... ({done}/{total})"
                         ),
                     )
 
-                progress.update(task, description="Triggering network rediscovery...")
+                update("Triggering network rediscovery...")
                 trigger_rediscovery(client)
 
             except ManagerAPIError as e:

--- a/src/catalyst_sdwan_lab/tasks/setup.py
+++ b/src/catalyst_sdwan_lab/tasks/setup.py
@@ -1,40 +1,34 @@
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import typer
 import yaml
-from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 from virl2_client import ClientLibrary
 
-from .utils import CML_NODES_DEFINITION_DIR, connect_cml, console
+from .utils import CML_NODES_DEFINITION_DIR, connect_cml, console, task_progress
 
 log = logging.getLogger(__name__)
 _IOL_NODE_IDS = ("iol-xe", "ioll2-xe")
 
 
 def run(cml_host: str, cml_user: str, cml_password: str) -> None:
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        console=console,
-        transient=True,
-    ) as progress:
-        task = progress.add_task("Connecting to CML...")
+    with task_progress(console) as update:
         cml = connect_cml(cml_host, cml_user, cml_password)
         try:
-            progress.update(task, description="Checking license...")
+            update("Checking license...")
             _check_license(cml)
             log.info("License OK")
 
-            progress.update(task, description="Loading node definitions...")
+            update("Loading node definitions...")
             existing = {nd["id"]: nd for nd in cml.definitions.node_definitions()}
             log.debug("Loaded %d node definitions from CML", len(existing))
 
-            progress.update(task, description="Checking IOL definitions...")
+            update("Checking IOL definitions...")
             _check_iol_definitions(existing)
             log.info("IOL definitions found")
 
-            _sync_node_definitions(cml, existing, progress, task)
+            _sync_node_definitions(cml, existing, update)
         finally:
             cml.logout()
 
@@ -63,13 +57,12 @@ def _check_iol_definitions(existing: dict[str, Any]) -> None:
 def _sync_node_definitions(
     cml: ClientLibrary,
     existing: dict[str, Any],
-    progress: Progress,
-    task: TaskID,
+    update: Callable[[str], None],
 ) -> None:
     for path in sorted(CML_NODES_DEFINITION_DIR.glob("*.yaml")):
         definition = yaml.safe_load(path.read_text())
         node_id = definition["id"]
-        progress.update(task, description=f"Checking {node_id}...")
+        update(f"Checking {node_id}...")
         if node_id not in existing:
             log.debug("%s: not found in CML, uploading", node_id)
             cml.definitions.upload_node_definition(definition)

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -7,8 +7,9 @@ import os
 import re
 import tarfile
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -21,6 +22,7 @@ from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric.types import CertificateIssuerPrivateKeyTypes
 from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TaskID, TextColumn
 from virl2_client import ClientLibrary
 from virl2_client.exceptions import APIError
 from virl2_client.models.lab import Lab
@@ -706,3 +708,30 @@ def run_sastre_task(
         if output:
             for entry in output:
                 log.debug("Sastre: %s", entry)
+
+
+@contextmanager
+def task_progress(
+    console: Console,
+    initial: str = "Connecting to CML...",
+) -> Iterator[Callable[[str], None]]:
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task(initial)
+
+        def update(msg: str) -> None:
+            progress.update(task, description=msg)
+            log.info(msg)
+
+        yield update
+
+
+def make_updater(progress: Progress, task: TaskID) -> Callable[[str], None]:
+    def update(msg: str) -> None:
+        progress.update(task, description=msg)
+        log.info(msg)
+    return update

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -56,10 +56,9 @@ class TestSyncNodeDefinitions:
             "id: cat-sdwan-manager\ngeneral:\n  read_only: false\ndata: value\n"
         )
         cml = MagicMock()
-        progress, task = MagicMock(), MagicMock()
 
         with patch("catalyst_sdwan_lab.tasks.setup.CML_NODES_DEFINITION_DIR", tmp_path):
-            _sync_node_definitions(cml, existing={}, progress=progress, task=task)
+            _sync_node_definitions(cml, existing={}, update=MagicMock())
 
         cml.definitions.upload_node_definition.assert_called_once_with(definition)
 
@@ -73,10 +72,9 @@ class TestSyncNodeDefinitions:
             }
         }
         cml = MagicMock()
-        progress, task = MagicMock(), MagicMock()
 
         with patch("catalyst_sdwan_lab.tasks.setup.CML_NODES_DEFINITION_DIR", tmp_path):
-            _sync_node_definitions(cml, existing=existing, progress=progress, task=task)
+            _sync_node_definitions(cml, existing=existing, update=MagicMock())
 
         cml.definitions.upload_node_definition.assert_called_once()
         _, kwargs = cml.definitions.upload_node_definition.call_args
@@ -92,10 +90,9 @@ class TestSyncNodeDefinitions:
             }
         }
         cml = MagicMock()
-        progress, task = MagicMock(), MagicMock()
 
         with patch("catalyst_sdwan_lab.tasks.setup.CML_NODES_DEFINITION_DIR", tmp_path):
-            _sync_node_definitions(cml, existing=existing, progress=progress, task=task)
+            _sync_node_definitions(cml, existing=existing, update=MagicMock())
 
         cml.definitions.upload_node_definition.assert_not_called()
 
@@ -109,10 +106,9 @@ class TestSyncNodeDefinitions:
             }
         }
         cml = MagicMock()
-        progress, task = MagicMock(), MagicMock()
 
         with patch("catalyst_sdwan_lab.tasks.setup.CML_NODES_DEFINITION_DIR", tmp_path):
-            _sync_node_definitions(cml, existing=existing, progress=progress, task=task)
+            _sync_node_definitions(cml, existing=existing, update=MagicMock())
 
         cml.definitions.set_node_definition_read_only.assert_called_once_with(
             "cat-sdwan-manager", False


### PR DESCRIPTION
## Description

Refactor progress reporting across all tasks to use a shared `task_progress` context manager and `make_updater` helper; every spinner update now also emits a `log.info` event, making task progress visible to log consumers (e.g. MCP server)
