### PR TITLE
Minor add and restore fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Catalyst SD-WAN Lab 3.1.3 [unreleased]
+
+- Fix `restore` failing with `Interface eth2 not found in VPN 0` if modified direct connectivity between SD-WAN Manager eth0 and external connector
+
 # Catalyst SD-WAN Lab 3.1.2 [Jul 9, 2026]
 
 - Fix `add` failing with `HTTP 400 Not Defined In Schema Attributes` against config groups (e.g. from an older tool version) that don't define per-device `_mask` variables — device variables are now filtered against the config group's actual schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Catalyst SD-WAN Lab 3.1.3 [unreleased]
 
 - Fix `restore` failing with `Interface eth2 not found in VPN 0` if modified direct connectivity between SD-WAN Manager eth0 and external connector
+- Fix `add` crashing with an unhandled `ReadTimeout` while polling for controller/validator reachability right after boot
 
 # Catalyst SD-WAN Lab 3.1.2 [Jul 9, 2026]
 

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal
 
+import requests
 import typer
 from jinja2 import Environment, FileSystemLoader
 from rich.markup import escape
@@ -569,7 +570,7 @@ def _add_to_manager_retrying(
         try:
             client.add_controller(ip, personality, "admin", "admin")
             return
-        except ManagerAPIError:
+        except (ManagerAPIError, requests.exceptions.RequestException):
             remaining = deadline - time.time()
             if remaining <= 0:
                 log.error("Timed out waiting for %s %s to become reachable.", personality, ip)

--- a/src/catalyst_sdwan_lab/tasks/restore.py
+++ b/src/catalyst_sdwan_lab/tasks/restore.py
@@ -422,10 +422,11 @@ def _restore_cluster(
     version: str,
     on_status: Callable[[str], None],
 ) -> ManagerClient:
-    secondary_managers = [
-        n for n in lab.nodes()
-        if n.node_definition == "cat-sdwan-manager" and not _manager_connected_to_external(n)
-    ]
+    manager_nodes = [n for n in lab.nodes() if n.node_definition == "cat-sdwan-manager"]
+    if len(manager_nodes) <= 1:
+        return client
+
+    secondary_managers = [n for n in manager_nodes if not _manager_connected_to_external(n)]
     if not secondary_managers:
         return client
 


### PR DESCRIPTION
## Description

- Fix `restore` failing with `Interface eth2 not found in VPN 0` if modified direct connectivity between SD-WAN Manager eth0 and external connector
- Fix `add` crashing with an unhandled `ReadTimeout` while polling for controller/validator reachability right after boot