### PR TITLE
add option to configure controllers via network-settings instead of attaching a device template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `restore` failing with `Interface eth2 not found in VPN 0` if modified direct connectivity between SD-WAN Manager eth0 and external connector
 - Fix `add` crashing with an unhandled `ReadTimeout` while polling for controller/validator reachability right after boot
+- Update `deploy`, `restore` and `add controller` to configure controllers via network-settings instead of attaching a device template (>=20.18)
 
 # Catalyst SD-WAN Lab 3.1.2 [Jul 9, 2026]
 

--- a/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/controller-cloud-init.j2
+++ b/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/controller-cloud-init.j2
@@ -96,5 +96,12 @@ write_files:
             <shutdown>false</shutdown>
           </interface>
         </vpn-instance>
+        <vpn-instance>
+          <vpn-id>512</vpn-id>
+          <interface>
+            <if-name>eth0</if-name>
+            <shutdown>false</shutdown>
+          </interface>
+        </vpn-instance>
       </vpn>
     </config>

--- a/src/catalyst_sdwan_lab/manager_client.py
+++ b/src/catalyst_sdwan_lab/manager_client.py
@@ -258,6 +258,21 @@ class ManagerClient:
     def get_controllers(self) -> list[dict[str, Any]]:
         return self._get("/dataservice/system/device/controllers").get("data", [])
 
+    def configure_control_component_network_settings(self, payload: dict[str, Any]) -> None:
+        self._post("/dataservice/v1/control-component/network-settings", payload)
+
+    def convert_control_component_to_settings(self, uuid: str) -> None:
+        self._post(f"/dataservice/v1/control-component/devices/{uuid}/settings/config-to-settings")
+
+    def deploy_control_component_settings(self, uuids: list[str]) -> str:
+        data = self._post(
+            "/dataservice/v1/control-component/devices/settings/deploy",
+            {"devices": [{"id": u} for u in uuids]},
+        )
+        if not data or "id" not in data:
+            raise ManagerAPIError("deploy_control_component_settings: missing id in response")
+        return data["id"]
+
     def get_network_hierarchy(self) -> list[dict[str, Any]]:
         return self._get("/dataservice/v1/network-hierarchy")
 

--- a/src/catalyst_sdwan_lab/tasks/add.py
+++ b/src/catalyst_sdwan_lab/tasks/add.py
@@ -31,6 +31,7 @@ from .utils import (
     CML_DEPLOY_TEMPLATES_DIR,
     SDWAN_CTRL_NODE_DEFS,
     VALIDATOR_FQDN,
+    configure_controller_network_settings,
     connect_cml,
     connect_manager,
     console,
@@ -39,6 +40,7 @@ from .utils import (
     ensure_cluster_ip_configured,
     find_lab,
     load_certs,
+    parse_version,
     resolve_image,
     sha512_crypt,
     sign_device_cert,
@@ -83,6 +85,8 @@ def run_control_component(
     is_ctrl = device_type == "controller"
     label_prefix = "Controller" if is_ctrl else "Validator"
     node_def = "cat-sdwan-controller" if is_ctrl else "cat-sdwan-validator"
+    major, minor, _ = parse_version(version)
+    use_network_settings = is_ctrl and (major, minor) >= (20, 18)
     certs = load_certs()
 
     with task_progress(console) as update:
@@ -97,7 +101,11 @@ def run_control_component(
         try:
             pki = client.get_certificate_signing()
             org_name = client.get_organization() or ""
-            template_id = _import_controller_templates(client, ip_type) if is_ctrl else None
+            template_id = (
+                _import_controller_templates(client, ip_type)
+                if is_ctrl and not use_network_settings
+                else None
+            )
 
             ip_offset = "1" if is_ctrl else "2"
             num_re = _CTRL_NUM_RE if is_ctrl else _VLDTR_NUM_RE
@@ -157,9 +165,13 @@ def run_control_component(
                 }
                 update("Waiting for controllers to reconnect...")
                 _wait_for_controllers_ready(client, system_ips, timeout=_CSR_POLL_TIMEOUT)
-                update("Attaching controller template...")
-                assert template_id is not None
-                _attach_controller_template(client, ip_type, template_id, system_ips)
+                if use_network_settings:
+                    update("Configuring controller network settings...")
+                    configure_controller_network_settings(client, system_ips)
+                else:
+                    update("Attaching controller template...")
+                    assert template_id is not None
+                    _attach_controller_template(client, ip_type, template_id, system_ips)
             else:
                 update("Updating Gateway DNS entries...")
                 _update_gateway_dns(

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -22,12 +22,14 @@ from .utils import (
     VALIDATOR_FQDN,
     Certs,
     basic_configuration_path,
+    configure_controller_network_settings,
     configure_manager,
     connect_cml,
     console,
     extract_org_name,
     load_certs,
     onboard_control_components,
+    parse_version,
     resolve_image,
     sha512_crypt,
     task_progress,
@@ -75,10 +77,7 @@ def run(
     if manager_password == "admin":
         log.error("Cannot use default credentials. Update Manager password and try again.")
         raise typer.Exit(1)
-    try:
-        major, minor, patch = (int(x) for x in (version.split(".")[:3] + ["0", "0"])[:3])
-    except ValueError:
-        major, minor, patch = 0, 0, 0
+    major, minor, patch = parse_version(version)
     if (major, minor) < (20, 15):
         log.error("Minimum supported Manager version is 20.15. Got: %s", version)
         raise typer.Exit(1)
@@ -159,11 +158,15 @@ def run(
                 update("Importing basic configuration...")
                 _restore_basic_configuration(client, ip_type)
 
-                update("Importing controller templates...")
-                template_id = _import_controller_templates(client, ip_type)
+                if (major, minor) >= (20, 18):
+                    update("Configuring controller network settings...")
+                    configure_controller_network_settings(client)
+                else:
+                    update("Importing controller templates...")
+                    template_id = _import_controller_templates(client, ip_type)
 
-                update("Attaching controller template...")
-                _attach_controller_template(client, ip_type, template_id)
+                    update("Attaching controller template...")
+                    _attach_controller_template(client, ip_type, template_id)
 
                 update("Triggering network rediscovery...")
                 trigger_rediscovery(client)

--- a/src/catalyst_sdwan_lab/tasks/restore.py
+++ b/src/catalyst_sdwan_lab/tasks/restore.py
@@ -20,6 +20,7 @@ from .utils import (
     Certs,
     check_serial_file_match,
     collect_control_components,
+    configure_controller_network_settings,
     configure_manager,
     connect_cml,
     console,
@@ -29,6 +30,7 @@ from .utils import (
     extract_org_name,
     load_certs,
     onboard_control_components,
+    parse_version,
     resolve_image,
     run_sastre_task,
     sha512_crypt,
@@ -91,15 +93,10 @@ def run(
         backup_version = raw_version if raw_version and raw_version[0].isdigit() else "20.15"
         version = control_version or backup_version
 
-        if pki == "cisco":
-            try:
-                parts = (version.split(".")[:3] + ["0", "0"])[:3]
-                major, minor, patch = (int(x) for x in parts)
-            except ValueError:
-                major, minor, patch = 0, 0, 0
-            if (major, minor, patch) < (20, 18, 2):
-                log.error("Cisco PKI requires Manager version 20.18.2 or later. Got: %s", version)
-                raise typer.Exit(1)
+        major, minor, patch = parse_version(version)
+        if pki == "cisco" and (major, minor, patch) < (20, 18, 2):
+            log.error("Cisco PKI requires Manager version 20.18.2 or later. Got: %s", version)
+            raise typer.Exit(1)
 
         update("Checking images...")
         _check_images(cml, topology, control_version, edge_version)
@@ -167,6 +164,12 @@ def run(
 
                 update("Patching Sastre controller UUIDs...")
                 _patch_sastre_controller_uuids(manager_configs_dir, client)
+
+                if (major, minor) >= (20, 18) and not _controllers_have_device_template(
+                    manager_configs_dir
+                ):
+                    update("Configuring controller network settings...")
+                    configure_controller_network_settings(client)
 
                 update("Patching config group passwords...")
                 _patch_config_group_passwords(manager_configs_dir)
@@ -545,6 +548,17 @@ def _patch_sastre_controller_uuids(manager_configs_dir: Path, client: ManagerCli
                     if new_uuid:
                         device["csv-deviceId"] = new_uuid
                 values_path.write_text(json.dumps(vdata, indent=2))
+
+
+def _controllers_have_device_template(manager_configs_dir: Path) -> bool:
+    attached_dir = manager_configs_dir / "device_templates" / "attached"
+    if not attached_dir.exists():
+        return False
+    for path in attached_dir.glob("*.json"):
+        data = json.loads(path.read_text())
+        if data and data[0].get("personality") == "vsmart":
+            return True
+    return False
 
 
 def _run_sastre_restore(

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -155,6 +155,14 @@ def load_certs() -> Certs:
     return Certs(**loaded)
 
 
+def parse_version(version: str) -> tuple[int, int, int]:
+    try:
+        major, minor, patch = (int(x) for x in (version.split(".")[:3] + ["0", "0"])[:3])
+    except ValueError:
+        return 0, 0, 0
+    return major, minor, patch
+
+
 def _normalize_version(version: str) -> str:
     def _pad(seg: str) -> str:
         i = 0
@@ -607,6 +615,69 @@ def trigger_rediscovery(client: ManagerClient) -> None:
     if reachable:
         client.rediscover_devices(reachable)
         log.info("Network rediscovery triggered for %d devices", len(reachable))
+
+
+CONTROLLER_NETWORK_SETTINGS: dict[str, Any] = {
+    "dns": {},
+    "ntp": {"server": [{"name": "time.google.com", "vpnId": 0, "prefer": False}]},
+    "aaa": {
+        "authOrder": ["local", "radius", "tacacs"],
+        "ciscoTacRoUser": True,
+        "ciscoTacRwUser": True,
+        "user": [{"name": "admin", "password": "admin"}],
+        "accounting": False,
+        "adminAuthOrder": False,
+        "authFallback": False,
+        "logs": {"auditDisable": False, "netconfDisable": False},
+    },
+    "banner": {"enableFeature": False},
+    "logging": {"enableFeature": False},
+    "snmp": {"enableFeature": False},
+    "controller": {
+        "omp": {
+            "shutdown": False,
+            "filterRoute": {"outbound": {"affinityGroupPreference": False, "tlocColor": False}},
+            "outboundPolicyCaching": True,
+            "sendBackupPaths": False,
+            "discardRejected": False,
+            "gracefulRestart": True,
+            "timers": {
+                "holdTime": 300,
+                "advertisementInterval": 1,
+                "gracefulRestartTimer": 43200,
+                "eorTimer": 300,
+            },
+        },
+        "hubSpokeTopology": False,
+    },
+    "security": {"protocol": "dtls"},
+}
+
+
+def get_controller_uuids(
+    client: ManagerClient, controller_ips: set[str] | None = None
+) -> list[str]:
+    return [
+        d["uuid"]
+        for d in client.get_controllers()
+        if d.get("personality") == "vsmart"
+        and (controller_ips is None or d.get("deviceIP") in controller_ips)
+    ]
+
+
+def configure_controller_network_settings(
+    client: ManagerClient, controller_ips: set[str] | None = None
+) -> None:
+    uuids = get_controller_uuids(client, controller_ips)
+    if not uuids:
+        log.debug("No controllers to configure — skipping")
+        return
+    for uuid in uuids:
+        client.convert_control_component_to_settings(uuid)
+    client.configure_control_component_network_settings(CONTROLLER_NETWORK_SETTINGS)
+    task_id = client.deploy_control_component_settings(uuids)
+    client.wait_for_task(task_id)
+    log.info("Controller network settings deployed to %d controller(s)", len(uuids))
 
 
 def ensure_cluster_ip_configured(

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -19,10 +19,13 @@ from catalyst_sdwan_lab.tasks.deploy import (
 )
 from catalyst_sdwan_lab.tasks.utils import (
     _complete_initial_setup_workflow,
+    configure_controller_network_settings,
     configure_manager,
     extract_org_name,
+    get_controller_uuids,
     load_certs,
     onboard_control_components,
+    parse_version,
     resolve_image,
     sign_device_cert,
 )
@@ -373,6 +376,60 @@ class TestAttachControllerTemplate:
         device = client.attach_device_template.call_args[0][1][0]
         assert "/0/eth1/interface/ip/address" in device
         assert "/0/eth1/interface/ipv6/address" in device
+
+
+class TestGetControllerUuids:
+    def _device(self, personality: str, ip: str, uuid: str) -> dict:
+        return {"personality": personality, "deviceIP": ip, "uuid": uuid}
+
+    def test_filters_to_vsmart_only(self) -> None:
+        client = MagicMock()
+        client.get_controllers.return_value = [
+            self._device("vsmart", "100.0.0.101", "uuid-1"),
+            self._device("vbond", "100.0.0.201", "uuid-2"),
+        ]
+        assert get_controller_uuids(client) == ["uuid-1"]
+
+    def test_filters_by_controller_ips_when_given(self) -> None:
+        client = MagicMock()
+        client.get_controllers.return_value = [
+            self._device("vsmart", "100.0.0.101", "uuid-1"),
+            self._device("vsmart", "100.0.0.102", "uuid-2"),
+        ]
+        assert get_controller_uuids(client, {"100.0.0.102"}) == ["uuid-2"]
+
+
+class TestConfigureControllerNetworkSettings:
+    def test_skips_if_no_controllers(self) -> None:
+        client = MagicMock()
+        client.get_controllers.return_value = []
+        configure_controller_network_settings(client)
+        client.convert_control_component_to_settings.assert_not_called()
+        client.configure_control_component_network_settings.assert_not_called()
+        client.deploy_control_component_settings.assert_not_called()
+
+    def test_configures_and_deploys_to_matching_controllers(self) -> None:
+        client = MagicMock()
+        client.get_controllers.return_value = [
+            {"personality": "vsmart", "deviceIP": "100.0.0.101", "uuid": "uuid-1"},
+        ]
+        client.deploy_control_component_settings.return_value = "task-1"
+        configure_controller_network_settings(client, {"100.0.0.101"})
+        client.convert_control_component_to_settings.assert_called_once_with("uuid-1")
+        client.configure_control_component_network_settings.assert_called_once()
+        client.deploy_control_component_settings.assert_called_once_with(["uuid-1"])
+        client.wait_for_task.assert_called_once_with("task-1")
+
+
+class TestParseVersion:
+    def test_full_version(self) -> None:
+        assert parse_version("20.18.2") == (20, 18, 2)
+
+    def test_short_version_defaults_patch(self) -> None:
+        assert parse_version("20.15") == (20, 15, 0)
+
+    def test_garbage_falls_back_to_zero(self) -> None:
+        assert parse_version("not-a-version") == (0, 0, 0)
 
 
 class TestCheckIpFree:

--- a/tests/test_restore.py
+++ b/tests/test_restore.py
@@ -1,8 +1,10 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from catalyst_sdwan_lab.tasks.restore import (
+    _controllers_have_device_template,
     _find_backup_root,
     _find_primary_manager_id,
     _load_backup,
@@ -110,3 +112,22 @@ class TestLoadBackup:
 
         assert manager_configs_dir.is_absolute()
         assert tmpdir is None
+
+
+class TestControllersHaveDeviceTemplate:
+    def test_no_attached_dir_returns_false(self, tmp_path: Path) -> None:
+        assert _controllers_have_device_template(tmp_path) is False
+
+    def test_no_vsmart_entries_returns_false(self, tmp_path: Path) -> None:
+        attached = tmp_path / "device_templates" / "attached"
+        attached.mkdir(parents=True)
+        (attached / "edge_basic.json").write_text(json.dumps([{"personality": "vedge"}]))
+
+        assert _controllers_have_device_template(tmp_path) is False
+
+    def test_vsmart_entry_returns_true(self, tmp_path: Path) -> None:
+        attached = tmp_path / "device_templates" / "attached"
+        attached.mkdir(parents=True)
+        (attached / "controller_basic.json").write_text(json.dumps([{"personality": "vsmart"}]))
+
+        assert _controllers_have_device_template(tmp_path) is True


### PR DESCRIPTION
## Description

Update `deploy`, `restore` and `add controller` to configure controllers via network-settings instead of attaching a device template (>=20.18)