### PR TITLE
minor updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Catalyst SD-WAN Lab 3.1.5 [unreleased]
+
+- Fix `deploy`/`restore` skipping the initial setup workflow completion on Manager 20.18 (was gated to `>= 26`, but the feature was introduced in 20.18.1)
+- Fix `deploy` creating two duplicate `admin` users in SD-WAN Manager's cloud-init config when `--manager-user admin` is used (same value as the default account)
+
 # Catalyst SD-WAN Lab 3.1.4 [Jul 28, 2026]
 
 - Fix `restore` crashing with `TypeError: expected string or bytes-like object, got 'list'` when a backed-up edge node was inactive at backup time

--- a/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
+++ b/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/manager-cloud-init.j2
@@ -47,12 +47,14 @@ write_files:
             <last-password-change-time>{{ password_change_time }}</last-password-change-time>
             <group>netadmin</group>
           </user>
+{% if manager_user != 'admin' %}
           <user>
             <name>{{ manager_user }}</name>
             <password>{{ manager_pass }}</password>
             <last-password-change-time>{{ password_change_time }}</last-password-change-time>
             <group>netadmin</group>
           </user>
+{% endif %}
         </aaa>
       </system>
       <vpn xmlns="http://viptela.com/vpn">

--- a/src/catalyst_sdwan_lab/tasks/utils.py
+++ b/src/catalyst_sdwan_lab/tasks/utils.py
@@ -529,7 +529,7 @@ def configure_manager(
     client.settings_cloudx("on")
     log.info("SD-WAN Manager settings configured")
 
-    if int(version.split(".")[0]) >= 26:
+    if parse_version(version) >= (20, 18, 1):
         _complete_initial_setup_workflow(client)
 
 


### PR DESCRIPTION
## Description

- Fix `deploy`/`restore` skipping the initial setup workflow completion on Manager 20.18 (was gated to `>= 26`, but the feature was introduced in 20.18.1)
- Fix `deploy` creating two duplicate `admin` users in SD-WAN Manager's cloud-init config when `--manager-user admin` is used (same value as the default account)
