### PR TITLE
add cpu and ram overrides in deploy task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `deploy`/`restore` skipping the initial setup workflow completion on Manager 20.18 (was gated to `>= 26`, but the feature was introduced in 20.18.1)
 - Fix `deploy` creating two duplicate `admin` users in SD-WAN Manager's cloud-init config when `--manager-user admin` is used (same value as the default account)
+- Add per-node CPU/RAM overrides to `deploy` via `--manager-cpus`/`--manager-ram`, `--controller-cpus`/`--controller-ram` and `--validator-cpus`/`--validator-ram` (env vars `MANAGER_CPUS`, `MANAGER_RAM`, `CONTROLLER_CPUS`, `CONTROLLER_RAM`, `VALIDATOR_CPUS`, `VALIDATOR_RAM`); each node keeps its image default unless overridden, and overrides are ignored with `--retry`
 
 # Catalyst SD-WAN Lab 3.1.4 [Jul 28, 2026]
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ csdwan deploy [OPTIONS] <version>
 | `--proxy-ip` | `PROXY_IP` | HTTP proxy hostname or IP for Manager's outbound connections |
 | `--proxy-port` | `PROXY_PORT` | HTTP proxy port (default: `80`) |
 | `--no-proxy` | `NO_PROXY` | Additional no-proxy entries; RFC1918 ranges are always excluded |
+| `--manager-cpus` | `MANAGER_CPUS` | Override CPU count for the Manager node |
+| `--manager-ram` | `MANAGER_RAM` | Override RAM in MB for the Manager node |
+| `--controller-cpus` | `CONTROLLER_CPUS` | Override CPU count for the Controller node |
+| `--controller-ram` | `CONTROLLER_RAM` | Override RAM in MB for the Controller node |
+| `--validator-cpus` | `VALIDATOR_CPUS` | Override CPU count for the Validator node |
+| `--validator-ram` | `VALIDATOR_RAM` | Override RAM in MB for the Validator node |
 
 **Manager connectivity modes:**
 
@@ -194,6 +200,18 @@ csdwan deploy 20.15.1 \
 ```sh
 csdwan deploy 20.15.1 --manager-port 2000 --lab my-lab
 ```
+
+**Resource overrides:**
+
+Each control-plane node keeps its image default unless overridden. Any subset of the six options can be used:
+
+```sh
+csdwan deploy 20.15.1 --manager-port 2000 --lab my-lab \
+  --manager-cpus 8 --manager-ram 32768 \
+  --controller-ram 4096
+```
+
+The values can also be set once in `lab.env` via their env vars. Overrides only apply when the lab is created, so they are ignored with `--retry`.
 
 ---
 

--- a/src/catalyst_sdwan_lab/cli.py
+++ b/src/catalyst_sdwan_lab/cli.py
@@ -226,6 +226,36 @@ def deploy(
             help="Additional no-proxy entries (10.*, 172.*, 192.168.* are always excluded)",
         ),
     ] = "",
+    manager_cpus: Annotated[
+        Optional[int],
+        typer.Option("--manager-cpus", envvar="MANAGER_CPUS",
+                     help="Override number of CPUs for the Manager node"),
+    ] = None,
+    manager_ram: Annotated[
+        Optional[int],
+        typer.Option("--manager-ram", envvar="MANAGER_RAM",
+                     help="Override RAM in MB for the Manager node"),
+    ] = None,
+    controller_cpus: Annotated[
+        Optional[int],
+        typer.Option("--controller-cpus", envvar="CONTROLLER_CPUS",
+                     help="Override number of CPUs for the Controller node"),
+    ] = None,
+    controller_ram: Annotated[
+        Optional[int],
+        typer.Option("--controller-ram", envvar="CONTROLLER_RAM",
+                     help="Override RAM in MB for the Controller node"),
+    ] = None,
+    validator_cpus: Annotated[
+        Optional[int],
+        typer.Option("--validator-cpus", envvar="VALIDATOR_CPUS",
+                     help="Override number of CPUs for the Validator node"),
+    ] = None,
+    validator_ram: Annotated[
+        Optional[int],
+        typer.Option("--validator-ram", envvar="VALIDATOR_RAM",
+                     help="Override RAM in MB for the Validator node"),
+    ] = None,
 ) -> None:
     """Deploy a Catalyst SD-WAN lab in CML."""
     if pki not in ("enterprise", "cisco"):
@@ -267,6 +297,12 @@ def deploy(
         proxy_ip=proxy_ip or "",
         proxy_port=proxy_port,
         no_proxy=no_proxy,
+        manager_cpus=manager_cpus,
+        manager_ram=manager_ram,
+        controller_cpus=controller_cpus,
+        controller_ram=controller_ram,
+        validator_cpus=validator_cpus,
+        validator_ram=validator_ram,
     )
 
 

--- a/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/cml-base-topology.j2
+++ b/src/catalyst_sdwan_lab/data/cml_lab_definition/deploy/cml-base-topology.j2
@@ -36,14 +36,14 @@ nodes:
 {% endfilter %}
 
     cpu_limit: null
-    cpus: null
+    cpus: {{ manager_cpus or 'null' }}
     data_volume: null
     hide_links: false
     id: n0
     image_definition: {{ manager_image }}
     label: Manager0{{ manager_num }}
     node_definition: cat-sdwan-manager
-    ram: null
+    ram: {{ manager_ram or 'null' }}
 {% if patty_used %}
     tags:
       - pat:{{ manager_port }}:443
@@ -76,14 +76,14 @@ nodes:
 {% endfilter %}
 
     cpu_limit: null
-    cpus: null
+    cpus: {{ controller_cpus or 'null' }}
     data_volume: null
     hide_links: false
     id: n1
     image_definition: {{ controller_image }}
     label: Controller{{ controller_num }}
     node_definition: cat-sdwan-controller
-    ram: null
+    ram: {{ controller_ram or 'null' }}
     tags: []
     x: -40
     y: -80
@@ -111,14 +111,14 @@ nodes:
 {% endfilter %}
 
     cpu_limit: null
-    cpus: null
+    cpus: {{ validator_cpus or 'null' }}
     data_volume: null
     hide_links: false
     id: n2
     image_definition: {{ validator_image }}
     label: Validator{{ validator_num }}
     node_definition: cat-sdwan-validator
-    ram: null
+    ram: {{ validator_ram or 'null' }}
     tags: []
     x: -160
     y: -80

--- a/src/catalyst_sdwan_lab/mcp_server.py
+++ b/src/catalyst_sdwan_lab/mcp_server.py
@@ -131,6 +131,12 @@ async def deploy(
     proxy_ip: str = "",
     proxy_port: str = "80",
     no_proxy: str = "",
+    manager_cpus: int | None = None,
+    manager_ram: int | None = None,
+    controller_cpus: int | None = None,
+    controller_ram: int | None = None,
+    validator_cpus: int | None = None,
+    validator_ram: int | None = None,
     cml_host: str | None = None,
     cml_user: str | None = None,
     cml_password: str | None = None,
@@ -166,6 +172,12 @@ async def deploy(
         proxy_ip: HTTP proxy hostname or IP
         proxy_port: HTTP proxy port (default: "80")
         no_proxy: Additional no-proxy entries
+        manager_cpus: Override number of CPUs for the Manager node
+        manager_ram: Override RAM in MB for the Manager node
+        controller_cpus: Override number of CPUs for the Controller node
+        controller_ram: Override RAM in MB for the Controller node
+        validator_cpus: Override number of CPUs for the Validator node
+        validator_ram: Override RAM in MB for the Validator node
         cml_host: CML hostname or IP (or set CML_IP env var)
         cml_user: CML username (or set CML_USER env var)
         cml_password: CML password (or set CML_PASSWORD env var)
@@ -208,6 +220,12 @@ async def deploy(
         proxy_ip=proxy_ip,
         proxy_port=proxy_port,
         no_proxy=no_proxy,
+        manager_cpus=manager_cpus,
+        manager_ram=manager_ram,
+        controller_cpus=controller_cpus,
+        controller_ram=controller_ram,
+        validator_cpus=validator_cpus,
+        validator_ram=validator_ram,
     )
     return _started("deploy", job_id)
 

--- a/src/catalyst_sdwan_lab/tasks/deploy.py
+++ b/src/catalyst_sdwan_lab/tasks/deploy.py
@@ -73,6 +73,12 @@ def run(
     proxy_ip: str = "",
     proxy_port: str = "80",
     no_proxy: str = "",
+    manager_cpus: int | None = None,
+    manager_ram: int | None = None,
+    controller_cpus: int | None = None,
+    controller_ram: int | None = None,
+    validator_cpus: int | None = None,
+    validator_ram: int | None = None,
 ) -> None:
     if manager_password == "admin":
         log.error("Cannot use default credentials. Update Manager password and try again.")
@@ -84,6 +90,14 @@ def run(
     if pki == "cisco" and (major, minor, patch) < (20, 18, 2):
         log.error("Cisco PKI requires Manager version 20.18.2 or later. Got: %s", version)
         raise typer.Exit(1)
+    if retry and any(
+        v is not None
+        for v in (
+            manager_cpus, manager_ram, controller_cpus,
+            controller_ram, validator_cpus, validator_ram,
+        )
+    ):
+        log.warning("CPU/RAM overrides are ignored with --retry; the lab already exists.")
 
     try:
         org_name = extract_org_name(serial_file)
@@ -122,6 +136,12 @@ def run(
                     dns_server=dns_server,
                     ip_type=ip_type,
                     patty=patty,
+                    manager_cpus=manager_cpus,
+                    manager_ram=manager_ram,
+                    controller_cpus=controller_cpus,
+                    controller_ram=controller_ram,
+                    validator_cpus=validator_cpus,
+                    validator_ram=validator_ram,
                 )
 
             update("Waiting for SD-WAN Manager...")
@@ -315,6 +335,12 @@ def _create_lab(
     dns_server: str,
     ip_type: str,
     patty: bool,
+    manager_cpus: int | None = None,
+    manager_ram: int | None = None,
+    controller_cpus: int | None = None,
+    controller_ram: int | None = None,
+    validator_cpus: int | None = None,
+    validator_ram: int | None = None,
 ) -> Any:
     existing = [lab.title for lab in cml.all_labs(show_all=True)]
     if lab_name in existing:
@@ -354,6 +380,12 @@ def _create_lab(
         patty_used=patty,
         password_change_time=now,
         persona="COMPUTE_AND_DATA",
+        manager_cpus=manager_cpus,
+        manager_ram=manager_ram,
+        controller_cpus=controller_cpus,
+        controller_ram=controller_ram,
+        validator_cpus=validator_cpus,
+        validator_ram=validator_ram,
     )
 
     log.info("Importing lab '%s' to CML...", lab_name)

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -6,10 +6,12 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from typer import Exit
 
 from catalyst_sdwan_lab.manager_client import ManagerAPIError
 from catalyst_sdwan_lab.tasks.deploy import (
+    _TOPOLOGY_ENV,
     _attach_controller_template,
     _check_ip_free,
     _find_lab,
@@ -524,3 +526,57 @@ class TestSignDeviceCert:
         client.generate_csr.side_effect = requests.exceptions.ConnectionError("down")
         with pytest.raises(ManagerAPIError, match="Certificate signing failed"):
             sign_device_cert(client, MagicMock(), "172.16.0.101")
+
+
+class TestBaseTopologyResources:
+    @staticmethod
+    def _render(**kwargs: object) -> dict:
+        topology = _TOPOLOGY_ENV.get_template("cml-base-topology.j2").render(
+            title="lab",
+            manager_num="1",
+            controller_num="01",
+            validator_num="01",
+            **kwargs,
+        )
+        return yaml.safe_load(topology)
+
+    @staticmethod
+    def _node(topology: dict, label: str) -> dict:
+        return next(n for n in topology["nodes"] if n["label"] == label)
+
+    def test_defaults_to_image_values(self) -> None:
+        topology = self._render()
+        for label in ("Manager01", "Controller01", "Validator01"):
+            node = self._node(topology, label)
+            assert node["cpus"] is None
+            assert node["ram"] is None
+
+    def test_overrides_applied_per_role(self) -> None:
+        topology = self._render(
+            manager_cpus=8,
+            manager_ram=32768,
+            controller_cpus=2,
+            controller_ram=4096,
+            validator_cpus=3,
+            validator_ram=5120,
+        )
+        manager = self._node(topology, "Manager01")
+        assert (manager["cpus"], manager["ram"]) == (8, 32768)
+        controller = self._node(topology, "Controller01")
+        assert (controller["cpus"], controller["ram"]) == (2, 4096)
+        validator = self._node(topology, "Validator01")
+        assert (validator["cpus"], validator["ram"]) == (3, 5120)
+
+    def test_partial_override_leaves_others_default(self) -> None:
+        topology = self._render(manager_ram=32768)
+        manager = self._node(topology, "Manager01")
+        assert manager["ram"] == 32768
+        assert manager["cpus"] is None
+        assert self._node(topology, "Controller01")["ram"] is None
+
+    def test_infra_nodes_unaffected(self) -> None:
+        topology = self._render(manager_cpus=8, manager_ram=32768)
+        for label in ("VPN0", "Gateway", "INET", "MPLS"):
+            node = self._node(topology, label)
+            assert node["cpus"] is None
+            assert node["ram"] is None


### PR DESCRIPTION
## Description

Add per-node CPU/RAM overrides to `deploy` via `--manager-cpus`/`--manager-ram`, `--controller-cpus`/`--controller-ram` and `--validator-cpus`/`--validator-ram` (env vars `MANAGER_CPUS`, `MANAGER_RAM`, `CONTROLLER_CPUS`, `CONTROLLER_RAM`, `VALIDATOR_CPUS`, `VALIDATOR_RAM`); each node keeps its image default unless overridden, and overrides are ignored with `--retry`