### PR TITLE
Inline scorecard workflow, pin scorecard-action to v2.4.4

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,10 +13,31 @@ permissions: read-all
 
 jobs:
   run-scorecard:
-    uses: cisco-ospo/.github/.github/workflows/_scorecard.yml@main
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       security-events: write
-    secrets: inherit
-    with:
-      publish-results: true
+    steps:
+      - name: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: run scorecard analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: upload sarif artifact
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: upload sarif results
+        uses: github/codeql-action/upload-sarif@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
The shared cisco-ospo/.github reusable workflow pins ossf/scorecard-action at v2.4.0, whose container image lives on gcr.io — now shut down — so every run fails with "Docker pull failed with exit code 1" before any analysis happens. v2.4.1 moved the image to ghcr.io.

The upstream fix (cisco-ospo/.github#466) has been open and unreviewed since Jul 27, so inline the workflow instead. This also puts the action pin where this repo's Dependabot can see it: a `uses: ...@main` reusable-workflow call is a branch ref with nothing to bump, and the pins inside it are invisible.

Verified on a branch that v2.4.4 pulls: the run got past the image pull and failed inside the container on "Only the default branch main is supported", which is as far as a non-default ref can be tested. The remaining unknowns — SARIF upload and the OpenSSF workflow-structure validation that governs publish_results — can only be exercised on main.

The other three action pins are carried over from the upstream workflow unchanged; Dependabot will bump them now that they are visible here.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
