### PR TITLE
Bump scorecard workflow actions off deprecated Node 20

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -31,13 +31,13 @@ jobs:
           publish_results: true
 
       - name: upload sarif artifact
-        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: upload sarif results
-        uses: github/codeql-action/upload-sarif@afb54ba388a7dca6ecae48f608c4ff05ff4cc77a # v3.25.15
+        uses: github/codeql-action/upload-sarif@b96794f015dfd88f77b49b1c93e0fa7110f94c63 # v4.38.0
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Problem

The `run-scorecard` job emits a deprecation warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/checkout@b4ffde6`, `actions/upload-artifact@0b2256b`, `github/codeql-action/upload-sarif@afb54ba`

These three pins came over unchanged in #206 from the shared `cisco-ospo/.github` workflow, where they had not been touched since Jul 2024. GitHub is currently forcing them onto Node 24; once that fallback is removed they will fail outright.

## Change

Bump to current releases, each verified to declare `using: node24`:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4.1.1 | v7.0.1 |
| `actions/upload-artifact` | v4.3.4 | v7.0.1 |
| `github/codeql-action/upload-sarif` | v3.25.15 | v4.38.0 |

SHAs resolved from each repository's tag rather than copied from a third party.

## Compatibility

- Every input this workflow passes still exists in the new versions: `persist-credentials`, `name`, `path`, `retention-days`, `sarif_file`.
- All three remain on Scorecard's approved-action allowlist, so `publish_results: true` is unaffected — the allowlist matches on action identity, not version.
- Verified green on `main` in [run 34594267997](https://github.com/cisco-open/sdwan-lab-deployment-tool/actions/runs/34594267997) before this change, so any regression here is attributable to the bump alone.

Dependabot would have proposed these eventually now that the pins are inlined and visible to it; this just does it in one reviewed change instead of three separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
